### PR TITLE
fix: enforce consistent log severity policy across library modules

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,20 @@
 # Changelog
 
+## [0.3.1] - 2026-04-05
+### Fix: consistent log severity policy and `getLogger(__name__)` usage
+- Added `import logging` and `logger = logging.getLogger(__name__)` to `llm_modules/llm_model.py` and `llm_modules/CheckTitleRelevance.py`, which previously had no logger
+- Downgraded all node entry/exit banners (e.g. `"----- Executing … -----"`, `"----- … completed -----"`) from `INFO` to `DEBUG` in `helper_nodes/graph1_sample.py`, `helper_nodes/graph5_sample.py`, `llm_modules/LLMNodes/subgraphs/translator_en_subgraph.py`, `llm_modules/LLMNodes/subgraphs/translator_usr_subgraph.py`, and `helper_modules/submodules.py`
+- Downgraded per-streaming-event banners (`"=== EVENT ==="` / `"============="`) in `graf/graph_base.py` from `INFO` to `DEBUG`
+- Downgraded subgraf workflow start/complete banners in `graf/subgrafs/message_translator_subgraf.py`, `graf/subgrafs/translator_en_subgraf.py`, and `graf/subgrafs/translator_usr_subgraf.py` from `INFO` to `DEBUG`
+- Downgraded retry-sleep messages in `llm_modules/robust_invoke.py` and `llm_modules/robust_invoke_async.py` from `INFO` to `DEBUG`; preceding rate-limit `WARNING` is unchanged
+- Downgraded `"Counting tokens"` in `helper_modules/token_counter/token_counter.py` from `INFO` to `DEBUG`
+- Downgraded token counter node factory message in `helper_modules/token_counter/generic_counter_node.py` from `INFO` to `DEBUG`
+- Downgraded translated component value log in `messages/compose_message.py` from `INFO` to `DEBUG`
+- Downgraded formatted-timestamp detail log in `helper_modules/submodules.py` from `INFO` to `DEBUG`
+- Demoted `logger.critical()` to `logger.error()` for four recoverable error sites in `graf/graph_base.py`: compile failure, workflow streaming failure, event serialisation failure, and file open/create failure; `"Failed to create session folder"` in `helper_modules/submodules.py` remains `CRITICAL`
+- Replaced `print(result["parallel_results"])` in the docstring example of `process.py` with `logger.debug(result["parallel_results"])`
+- Added a **Logging** section to `DEVELOPMENT.md` documenting the severity policy table and the rule against configuring root logger handlers inside library modules
+
 ## [0.3.0] - 2026-04-04
 ### Feature: parallel fan-out (scatter-gather) support
 - Added `BaseGraph.add_parallel_nodes(source_node, branch_nodes, merge_node, router_fn=None)` — wires a LangGraph `Send`-based fan-out from one node to a list of branch nodes that execute concurrently, followed by a merge/aggregation node; an optional `router_fn` controls per-branch state

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -234,3 +234,35 @@ def my_node(state):
     result = subgraf.run(extra_input={"data": state["data"]})
     return {"subgraf_result": result}
 ```
+
+## Logging
+
+### Library logging rule
+
+Every module that emits log messages must obtain its logger with:
+
+```python
+import logging
+logger = logging.getLogger(__name__)
+```
+
+Library modules must **never** call `logging.basicConfig()` or add handlers to the root logger.
+That is the sole responsibility of the consuming application.
+A consumer can silence all routine library output with one line:
+
+```python
+logging.getLogger("black_langcube").setLevel(logging.WARNING)
+```
+
+Example scripts in `src/black_langcube/examples/` are entry-point scripts and may configure
+logging for demonstration purposes — this is expected and intentional.
+
+### Severity policy
+
+| Level | Use for |
+|---|---|
+| `DEBUG` | Routine per-invocation detail: node entry/exit banners, retry sleep messages, token counts, individual streaming events |
+| `INFO` | Successful high-level state transitions: graph completed, session folder created |
+| `WARNING` | Non-fatal unexpected conditions: missing optional config, fallback triggered, empty result list |
+| `ERROR` | Recoverable failures: file not found, invalid JSON line, API error after all retries, language key missing |
+| `CRITICAL` | Unrecoverable / process-threatening failures only (use sparingly; currently only "Failed to create session folder") |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "black_langcube"
-version = "0.3.0"
+version = "0.3.1"
 description = "A LangGraph-based extension framework for complex workflow applications, enabling the integration of various AI models and tools into a cohesive system."
 readme = "README.md"
 license = "MIT"

--- a/src/black_langcube/graf/graph_base.py
+++ b/src/black_langcube/graf/graph_base.py
@@ -136,7 +136,7 @@ class BaseGraph:
         try:
             return self.workflow.compile()
         except Exception as e:
-            logger.critical("Error compiling review subgraph")
+            logger.error("Error compiling review subgraph")
             raise RuntimeError("Error compiling review subgraph") from e
 
     @property
@@ -187,7 +187,7 @@ class BaseGraph:
                 events.append(event)
             return events
         except Exception as e:
-            logger.critical(f"Error running workflow for {self.workflow_name}")
+            logger.error(f"Error running workflow for {self.workflow_name}")
             raise RuntimeError(
                 f"Error running workflow for {self.workflow_name}"
             ) from e
@@ -202,7 +202,7 @@ class BaseGraph:
         try:
             async with aiofiles.open(file_path, "a", encoding="utf-8") as output_file:
                 for s in events:
-                    logger.info("=== EVENT ===")
+                    logger.debug("=== EVENT ===")
                     try:
                         await output_file.write(
                             json.dumps(
@@ -213,15 +213,15 @@ class BaseGraph:
                             + "\n"
                         )
                     except Exception as e:
-                        logger.critical(
+                        logger.error(
                             f"Error writing to '{output_filename}' in {subfolder}"
                         )
                         raise RuntimeError(
                             f"Error writing to '{output_filename}' in {subfolder}"
                         ) from e
-                    logger.info("=============")
+                    logger.debug("=============")
         except OSError as e:
-            logger.critical(
+            logger.error(
                 f"Error creating or opening '{output_filename}' in {subfolder}"
             )
             raise RuntimeError(

--- a/src/black_langcube/graf/subgrafs/message_translator_subgraf.py
+++ b/src/black_langcube/graf/subgrafs/message_translator_subgraf.py
@@ -71,7 +71,7 @@ class MessageTranslatorSubgraf(
         return "message_translator_subgraf"
 
     async def run(self, extra_input=None):
-        logger.info("--- Starting MessageTranslatorSubgraf workflow ---")
+        logger.debug("--- Starting MessageTranslatorSubgraf workflow ---")
         events = await self.graph_streaming(extra_input or {}, recursion_limit=10)
         subfolder = await self.write_events_to_file(events, self.output_filename)
         from black_langcube.messages.subgraphs.message_message_translator import (
@@ -81,5 +81,5 @@ class MessageTranslatorSubgraf(
         message = await message_message_translator(
             self.state.get("language"), subfolder, self.output_filename
         )
-        logger.info("--- MessageTranslatorSubgraf workflow completed ---")
+        logger.debug("--- MessageTranslatorSubgraf workflow completed ---")
         return message

--- a/src/black_langcube/graf/subgrafs/translator_en_subgraf.py
+++ b/src/black_langcube/graf/subgrafs/translator_en_subgraf.py
@@ -71,7 +71,7 @@ class TranslatorEnSubgraf(
         return "translator_en_subgraf"
 
     async def run(self, extra_input=None):
-        logger.info("--- Starting TranslatorEnSubgraf workflow ---")
+        logger.debug("--- Starting TranslatorEnSubgraf workflow ---")
         events = await self.graph_streaming(extra_input or {}, recursion_limit=10)
         subfolder = await self.write_events_to_file(events, self.output_filename)
         from black_langcube.messages.subgraphs.message_translator_en import (
@@ -81,5 +81,5 @@ class TranslatorEnSubgraf(
         message = await message_translator_en(
             self.state.get("language"), subfolder, self.output_filename
         )
-        logger.info("--- TranslatorEnSubgraf workflow completed ---")
+        logger.debug("--- TranslatorEnSubgraf workflow completed ---")
         return message

--- a/src/black_langcube/graf/subgrafs/translator_usr_subgraf.py
+++ b/src/black_langcube/graf/subgrafs/translator_usr_subgraf.py
@@ -72,7 +72,7 @@ class TranslatorUsrSubgraf(
         return "translator_usr_subgraf"
 
     async def run(self, extra_input=None):
-        logger.info("--- Starting TranslatorUsrSubgraf workflow ---")
+        logger.debug("--- Starting TranslatorUsrSubgraf workflow ---")
         events = await self.graph_streaming(extra_input or {}, recursion_limit=10)
         subfolder = await self.write_events_to_file(events, self.output_filename)
         from black_langcube.messages.subgraphs.message_translator_usr import (
@@ -82,5 +82,5 @@ class TranslatorUsrSubgraf(
         message = await message_translator_usr(
             self.state.get("language"), subfolder, self.output_filename
         )
-        logger.info("--- TranslatorUsrSubgraf workflow completed ---")
+        logger.debug("--- TranslatorUsrSubgraf workflow completed ---")
         return message

--- a/src/black_langcube/helper_modules/helper_nodes/graph1_sample.py
+++ b/src/black_langcube/helper_modules/helper_nodes/graph1_sample.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 def route_translatequestion_or_question2translation(
     state,
 ) -> Literal["translate_question", "question2translation"]:
-    logger.info("----- route_translatequestion_or_question2translation -----")
+    logger.debug("----- route_translatequestion_or_question2translation -----")
     # If the language starts with "English", we assume no translation is needed
     # and we route to Question2Translation, otherwise we route to TranslateQuestionNode
     if state["language"].startswith("English"):
@@ -32,13 +32,12 @@ class Question2Translation:
     def __init__(self, state, config):
         self.state = state
         self.config = config
-        self.logger = logging.getLogger(__name__)
 
     def execute(self, extra_input=None):
-        self.logger.info("----- Executing Question2Translation -----")
+        logger.debug("----- Executing Question2Translation -----")
         # Here we assume that the question is already in the desired format
         # and we simply return it as the translation.
         result = self.state["question"]
         self.state["question_translation"] = result
-        self.logger.info("----- Question2Translation execution completed -----")
+        logger.debug("----- Question2Translation execution completed -----")
         return {"question_translation": result}

--- a/src/black_langcube/helper_modules/helper_nodes/graph5_sample.py
+++ b/src/black_langcube/helper_modules/helper_nodes/graph5_sample.py
@@ -23,10 +23,9 @@ class ImportUtility:
     def __init__(self, state: dict, config: RunnableConfig):
         self.state = state
         self.config = config
-        self.logger = logging.getLogger(__name__)
 
     def execute(self, extra_input=None):
-        self.logger.info("----- Executing ImportUtility -----")
+        logger.debug("----- Executing ImportUtility -----")
         # Here we would implement the logic for importing the necessary data
         subfolder_name = Path(self.state["folder_name"]) / "graph4"
 
@@ -35,7 +34,7 @@ class ImportUtility:
                 "foo", "", "foo", "", subfolder_name, "graph4_output.json"
             )
         except (OSError, json.JSONDecodeError) as e:
-            self.logger.error("Error getting foo from graph4_output.json")
+            logger.error("Error getting foo from graph4_output.json")
             raise RuntimeError("Error getting foo from graph4_output.json") from e
 
         try:
@@ -43,22 +42,22 @@ class ImportUtility:
                 "bar", "", "baz", "", subfolder_name, "graph4_output.json"
             )
         except (OSError, json.JSONDecodeError) as e:
-            self.logger.error("Error getting bar from graph4_output.json")
+            logger.error("Error getting bar from graph4_output.json")
             raise RuntimeError("Error getting bar from graph4_output.json") from e
 
         # Check if foo and bar are lists
         if not isinstance(foo, list):
-            self.logger.error("foo is not a list")
+            logger.error("foo is not a list")
             raise ValueError("foo is not a list")
         if not isinstance(bar, list):
-            self.logger.error("bar is not a list")
+            logger.error("bar is not a list")
             raise ValueError("bar is not a list")
         # Check if foo and bar are not empty
         if not foo:
-            self.logger.warning("foo is empty, proceeding with an empty list")
+            logger.warning("foo is empty, proceeding with an empty list")
             foo = []
         if not bar:
-            self.logger.warning("bar is empty, proceeding with an empty list")
+            logger.warning("bar is empty, proceeding with an empty list")
             bar = []
 
         try:
@@ -66,7 +65,7 @@ class ImportUtility:
                 "baz", "", "user_language", "", subfolder_name, "graph4_output.json"
             )
         except (OSError, json.JSONDecodeError) as e:
-            self.logger.error("Error getting user_language from graph4_output.json")
+            logger.error("Error getting user_language from graph4_output.json")
             raise RuntimeError(
                 "Error getting user_language from graph4_output.json"
             ) from e
@@ -92,14 +91,14 @@ class ImportUtility:
                     "graph1_output.json",
                 )
         except (OSError, json.JSONDecodeError) as e:
-            self.logger.error(
+            logger.error(
                 "Error getting question_translation from graph1_output.json"
             )
             raise RuntimeError(
                 "Error getting question_translation from graph1_output.json"
             ) from e
 
-        self.logger.info("----- ImportUtility execution completed -----")
+        logger.debug("----- ImportUtility execution completed -----")
 
         self.state["foo"] = foo
         self.state["bar"] = bar

--- a/src/black_langcube/helper_modules/submodules.py
+++ b/src/black_langcube/helper_modules/submodules.py
@@ -32,12 +32,12 @@ def SessionCreator():
         RuntimeError: If the folder creation fails for any reason.
     """
 
-    logger.info("----- Session Node -----")
+    logger.debug("----- Session Node -----")
 
     # Get the current time as a formatted string
     formatted_timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
-    logger.info("Formatted Timestamp: %s", formatted_timestamp)
+    logger.debug("Formatted Timestamp: %s", formatted_timestamp)
 
     # Define the folder name
     folder_name = Path("./results") / formatted_timestamp

--- a/src/black_langcube/helper_modules/token_counter/generic_counter_node.py
+++ b/src/black_langcube/helper_modules/token_counter/generic_counter_node.py
@@ -34,7 +34,7 @@ def create_token_counter_node(token_keys, workflow_prefix):
       }
     """
 
-    logger.info(
+    logger.debug(
         f"Creating token counter node with prefix: {workflow_prefix} and keys: {token_keys}"
     )
 

--- a/src/black_langcube/helper_modules/token_counter/token_costs_count.py
+++ b/src/black_langcube/helper_modules/token_counter/token_costs_count.py
@@ -38,7 +38,7 @@ def TokenCostsCount(folder_name):
     It aggregates the token counts from multiple subfolders and writes the results to a file.
     """
 
-    logger.info(f"Calculating token costs for folder: {folder_name}")
+    logger.debug(f"Calculating token costs for folder: {folder_name}")
 
     subfolder1_name = Path(folder_name) / "graph1"
     subfolder2_name = Path(folder_name) / "graph2"

--- a/src/black_langcube/helper_modules/token_counter/token_counter.py
+++ b/src/black_langcube/helper_modules/token_counter/token_counter.py
@@ -30,7 +30,7 @@ class TokenCounter:
 
     def count_tokens(self, state: dict) -> dict:
 
-        logger.info("Counting tokens")
+        logger.debug("Counting tokens")
 
         total_tokens_in = sum(
             state.get(key, {}).get("tokens_in", 0) for key in self.token_keys

--- a/src/black_langcube/llm_modules/CheckTitleRelevance.py
+++ b/src/black_langcube/llm_modules/CheckTitleRelevance.py
@@ -1,8 +1,12 @@
+import logging
+
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.output_parsers import StrOutputParser
 from langchain_community.callbacks import get_openai_callback
 
 from black_langcube.llm_modules.llm_model import get_llm_low
+
+logger = logging.getLogger(__name__)
 
 
 def CheckTitleRelevance(title, topic):

--- a/src/black_langcube/llm_modules/LLMNodes/subgraphs/translator_en_subgraph.py
+++ b/src/black_langcube/llm_modules/LLMNodes/subgraphs/translator_en_subgraph.py
@@ -38,12 +38,12 @@ class TranslatorEngNode(LLMNode):
         ]
 
     async def execute(self, extra_input=None):
-        self.logger.info("----- Executing TranslatorEngNode -----")
+        self.logger.debug("----- Executing TranslatorEngNode -----")
         self.state["translation_input"] = extra_input.get("translation_input")
         self.state["language"] = extra_input.get("language")
         result, tokens = await self.run_chain(extra_input=extra_input)
 
-        self.logger.info("----- TranslatorEngNode execution completed -----")
+        self.logger.debug("----- TranslatorEngNode execution completed -----")
 
         return {
             "translation_output": result,

--- a/src/black_langcube/llm_modules/LLMNodes/subgraphs/translator_usr_subgraph.py
+++ b/src/black_langcube/llm_modules/LLMNodes/subgraphs/translator_usr_subgraph.py
@@ -42,12 +42,12 @@ class TranslatorUsrNode(LLMNode):
         return messages
 
     async def execute(self, extra_input=None):
-        self.logger.info("----- Executing TranslatorUsrNode -----")
+        self.logger.debug("----- Executing TranslatorUsrNode -----")
         self.state["translation_input"] = extra_input.get("translation_input")
         self.state["language"] = extra_input.get("language")
         result, tokens = await self.run_chain(extra_input=extra_input)
 
-        self.logger.info("----- TranslatorUsrNode execution completed -----")
+        self.logger.debug("----- TranslatorUsrNode execution completed -----")
 
         return {
             "translation_output": result,

--- a/src/black_langcube/llm_modules/llm_model.py
+++ b/src/black_langcube/llm_modules/llm_model.py
@@ -16,8 +16,12 @@ The module provides lazy factory functions for model access so that ChatOpenAI i
 
 from __future__ import annotations
 
+import logging
+
 from langchain_openai import ChatOpenAI
 from dotenv import load_dotenv, find_dotenv
+
+logger = logging.getLogger(__name__)
 
 _ = load_dotenv(find_dotenv())  # read local .env file
 

--- a/src/black_langcube/llm_modules/robust_invoke.py
+++ b/src/black_langcube/llm_modules/robust_invoke.py
@@ -53,7 +53,7 @@ def robust_invoke(chain, extra_input=None, max_retries=3, backoff_factor=65):
             logger.warning(f"Rate limit error: {e}")
             if attempt < max_retries - 1:
                 sleep_time = backoff_factor * attempt
-                logger.info(f"Retrying in {sleep_time} seconds...")
+                logger.debug(f"Retrying in {sleep_time} seconds...")
                 time.sleep(sleep_time)
             else:
                 return {

--- a/src/black_langcube/llm_modules/robust_invoke_async.py
+++ b/src/black_langcube/llm_modules/robust_invoke_async.py
@@ -72,7 +72,7 @@ async def robust_invoke_async(
             logger.warning(f"Rate limit error: {e}")
             if attempt < max_retries - 1:
                 sleep_time = backoff_factor * attempt
-                logger.info(f"Retrying in {sleep_time} seconds...")
+                logger.debug(f"Retrying in {sleep_time} seconds...")
                 await asyncio.sleep(sleep_time)
             else:
                 return {

--- a/src/black_langcube/messages/compose_message.py
+++ b/src/black_langcube/messages/compose_message.py
@@ -40,7 +40,7 @@ async def compose_message(language, components, subfolder=None):
                     translated = result[0]
                 else:
                     translated = str(result)
-                logger.info(translated)
+                logger.debug(translated)
                 message_parts.append(translated)
         else:
             if isinstance(comp, dict) and "error" in comp:

--- a/src/black_langcube/process.py
+++ b/src/black_langcube/process.py
@@ -261,7 +261,7 @@ async def run_parallel_pipeline(
         graph_b = MyGraph("message B", "output/b", "English")
 
         result = await run_parallel_pipeline([graph_a, graph_b])
-        print(result["parallel_results"])
+        logger.debug(result["parallel_results"])
     """
     if not graphs:
         raise ValueError("At least one graph must be provided to run_parallel_pipeline")


### PR DESCRIPTION
- Add logger = logging.getLogger(__name__) to llm_model.py and CheckTitleRelevance.py
- Downgrade node entry/exit banners, streaming events, retry-sleep, token counts, and translated-component logs from INFO to DEBUG
- Demote four recoverable logger.critical() sites in graph_base.py to error(); "Failed to create session folder" in submodules.py remains CRITICAL
- Replace print() in process.py docstring example with logger.debug()
- Remove self.logger from __init__ in graph1_sample.py and graph5_sample.py; use module-level logger throughout
- Add Logging section to DEVELOPMENT.md (severity policy table + library rule)
- Bump version 0.3.0 → 0.3.1