### PR TITLE
feat(llm): add multi-provider LLM factory with SecretStr API key prot…

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.3.3] - 2026-04-06
+### Feature: multi-provider LLM factory with SecretStr API key protection
+- Introduced `LLMProvider` (string enum: `OPENAI`, `GEMINI`, `MISTRAL`) and `ModelTier` (string enum: `LOW`, `HIGH`, `ANALYST`, `OUTLINE`, `TEXT`, `CHECK_TITLE`, `TITLE_ABSTRACT`) in `llm_modules/llm_model.py`
+- Added `MODEL_REGISTRY: dict[LLMProvider, dict[ModelTier, str]]` — a two-level dict mapping every `(provider, tier)` pair to a model name string sourced entirely from environment variables (e.g. `OPENAI_MODEL_LOW`, `GEMINI_MODEL_HIGH`) with sensible hard-coded defaults; adding a new model requires only an env var change, not a code change
+- Implemented `_load_secret(env_var)` helper that wraps environment variable values in `pydantic.SecretStr` and returns `None` when the variable is absent or empty; all three API key module-level constants (`OPENAI_API_KEY`, `GEMINI_API_KEY`, `MISTRAL_API_KEY`) are now `SecretStr | None` — no plain `str` key ever lives in the module namespace
+- Added `DEFAULT_PROVIDER: LLMProvider` — read from the `PROVIDER` env var at module load time, defaults to `LLMProvider.OPENAI`
+- Implemented `_resolve_provider(step_env_var)` — reads a per-step override env var (e.g. `ANALYST_PROVIDER`) and falls back to `DEFAULT_PROVIDER`; raises `ValueError` for unrecognised provider strings
+- Implemented `create_llm(provider, tier) -> BaseChatModel` factory — dispatches on `LLMProvider`, instantiates `ChatOpenAI` (OpenAI) or `ChatGoogleGenerativeAI` (Gemini) with the resolved model name and `SecretStr`-protected API key; raises `ValueError` for unsupported providers; provider-specific packages are imported lazily inside each branch so only the active provider's package needs to be installed
+- Rewrote all eight public alias functions (`get_llm_low`, `get_llm_high`, `default_llm`, `llm_analyst`, `llm_outline`, `llm_text`, `llm_check_title`, `llm_title_abstract`) as thin wrappers over `create_llm()`; existing call sites require no changes
+- `MISTRAL` is present in `LLMProvider` and `MODEL_REGISTRY` for forward compatibility; the factory branch for Mistral is not yet wired and raises `ValueError`
+- Added `langchain-google-genai>=2` as an optional dependency under `[project.optional-dependencies] gemini` in `pyproject.toml`; `langchain_google_genai` is imported lazily inside `create_llm()` so OpenAI-only users are not required to install it
+- Exported `LLMProvider` and `ModelTier` from the top-level `black_langcube` package (`__init__.py` and `__all__`)
+- Added `tests/test_llm_model.py` with 44 tests covering: enum values and string subclassing, `MODEL_REGISTRY` completeness and env-var defaults, `_load_secret()` for absent/empty/valid env vars, `SecretStr` non-leakage via `repr()` / `str()` / f-strings, `create_llm()` dispatch for all OpenAI and Gemini tiers with mocked constructors, correct model name forwarding, API key forwarding, `None` key handling, `ValueError` for Mistral and invalid providers, `_resolve_provider()` for step env vars and invalid values, all eight public alias delegation tests, and top-level package export tests; all tests pass with no real API key present
+
 ## [0.3.2] - 2026-04-05
 ### Feature: fail-fast configuration validation
 - Added `black_langcube/config.py` containing `ConfigurationError(Exception)`, `get_api_key(env_var)`, and `validate_config()`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "black_langcube"
-version = "0.3.2"
+version = "0.3.3"
 description = "A LangGraph-based extension framework for complex workflow applications, enabling the integration of various AI models and tools into a cohesive system."
 readme = "README.md"
 license = "MIT"
@@ -54,6 +54,12 @@ dev = [
 examples = [
     "jupyter",
     "notebook",
+]
+gemini = [
+    "langchain-google-genai>=2",
+]
+mistral = [
+    "langchain-mistralai>=0.2",
 ]
 
 [project.urls]

--- a/src/black_langcube/__init__.py
+++ b/src/black_langcube/__init__.py
@@ -2,13 +2,14 @@
 Black LangCube - A framework for building LLM applications with LangGraph.
 """
 
-__version__ = "0.3.2"
+__version__ = "0.3.3"
 __description__ = "A framework for building LLM applications with LangGraph"
 
 # Import core components to make them available from the main package
 from .config import ConfigurationError, validate_config
 from .graf.graph_base import BaseGraph, GraphState
 from .llm_modules.LLMNodes.LLMNode import LLMNode
+from .llm_modules.llm_model import LLMProvider, ModelTier
 from .helper_modules.get_basegraph_classes import get_basegraph_classes
 from .process import run_workflow_by_id, run_complete_pipeline, run_parallel_pipeline
 
@@ -19,6 +20,8 @@ __all__ = [
     "BaseGraph",
     "GraphState",
     "LLMNode",
+    "LLMProvider",
+    "ModelTier",
     "get_basegraph_classes",
     "run_workflow_by_id",
     "run_complete_pipeline",

--- a/src/black_langcube/llm_modules/llm_model.py
+++ b/src/black_langcube/llm_modules/llm_model.py
@@ -1,86 +1,210 @@
 """
-This module initializes and configures language model instances using the ChatOpenAI class from the langchain_openai package.
-It loads environment variables from a local .env file to securely manage credentials and settings.
-Two model names are specified: one for a lightweight model and one for a high-performance model, with recommendations to periodically check for updates in OpenAI's available models.
-The module provides lazy factory functions for model access so that ChatOpenAI instances are only created on first use, not at import time.
+Provider-agnostic LLM factory for black_langcube.
 
-    - langchain_openai.ChatOpenAI: Interface for OpenAI's chat-based language models.
-    - dotenv.load_dotenv, dotenv.find_dotenv: Utilities for loading environment variables from a .env file.
+Supports multiple LLM providers (OpenAI, Gemini, Mistral) selected at runtime via
+environment variables.  All API keys are wrapped in ``pydantic.SecretStr``
+to prevent accidental leakage in logs and tracebacks.
 
-    - model_name_low (str): Name of the lightweight language model (default: "gpt-4o-mini").
-    - model_name_high (str): Name of the high-performance language model (default: "gpt-4.1").
-    - get_llm_low() -> ChatOpenAI: Lazy singleton returning the lightweight model instance.
-    - get_llm_high() -> ChatOpenAI: Lazy singleton returning the high-performance model instance.
-    - default_llm, llm_analyst, llm_outline, llm_text, llm_check_title, llm_title_abstract: Lazy factory aliases for the models, used for specialized tasks.
+Environment variables
+---------------------
+PROVIDER
+    Default provider for all tiers (e.g. ``openai``, ``gemini``).
+    Defaults to ``openai``.
+
+<STEP>_PROVIDER
+    Per-step provider override.  ``<STEP>`` is one of ``LOW``, ``HIGH``,
+    ``ANALYST``, ``OUTLINE``, ``TEXT``, ``CHECK_TITLE``, ``TITLE_ABSTRACT``.
+
+OPENAI_API_KEY / GEMINI_API_KEY / MISTRAL_API_KEY
+    API keys for each provider.  Only the key for the active provider must
+    be set.
+
+<PROVIDER>_MODEL_<TIER>
+    Override the model name for a specific provider/tier combination, e.g.
+    ``OPENAI_MODEL_LOW=gpt-4o-mini``.
 """
 
 from __future__ import annotations
 
 import logging
+import os
+from enum import Enum
 
-from langchain_openai import ChatOpenAI
-from dotenv import load_dotenv, find_dotenv
-
-from black_langcube.config import get_api_key
+from dotenv import find_dotenv, load_dotenv
+from langchain_core.language_models.chat_models import BaseChatModel
+from pydantic import SecretStr
 
 logger = logging.getLogger(__name__)
 
 _ = load_dotenv(find_dotenv())  # read local .env file
 
-model_name_low = "gpt-4o-mini"  # this by default should be "gpt-4o-mini-2024-07-18" - changes in openAI available model policies should be checked periodically
-model_name_high = "gpt-4.1"  # this by default should be "gpt-4o-2024-08-06" - changes in openAI available model policies should be checked periodically
-
-# Lazy singletons — instantiated on first call, not at import time.
-_llm_low: ChatOpenAI | None = None
-_llm_high: ChatOpenAI | None = None
+# ---------------------------------------------------------------------------
+# Enums
+# ---------------------------------------------------------------------------
 
 
-def get_llm_low() -> ChatOpenAI:
-    global _llm_low
-    if _llm_low is None:
-        _llm_low = ChatOpenAI(
-            model=model_name_low,
-            openai_api_key=get_api_key("OPENAI_API_KEY"),
-        )
-    return _llm_low
+class LLMProvider(str, Enum):
+    OPENAI = "openai"
+    GEMINI = "gemini"
+    MISTRAL = "mistral"
+    # Extend when further providers are added
 
 
-def get_llm_high() -> ChatOpenAI:
-    global _llm_high
-    if _llm_high is None:
-        _llm_high = ChatOpenAI(
-            model=model_name_high,
-            openai_api_key=get_api_key("OPENAI_API_KEY"),
-        )
-    return _llm_high
+class ModelTier(str, Enum):
+    LOW = "low"
+    HIGH = "high"
+    ANALYST = "analyst"
+    OUTLINE = "outline"
+    TEXT = "text"
+    CHECK_TITLE = "check_title"
+    TITLE_ABSTRACT = "title_abstract"
 
 
-# Lazy factory aliases for the models:
+# ---------------------------------------------------------------------------
+# Model registry — all names sourced from environment variables with defaults
+# ---------------------------------------------------------------------------
+# NOTE: os.getenv() calls below are evaluated once at module import time.
+# Environment variable overrides (e.g. OPENAI_MODEL_LOW) must be set before
+# this module is first imported to take effect.
+MODEL_REGISTRY: dict[LLMProvider, dict[ModelTier, str]] = {
+    LLMProvider.OPENAI: {
+        ModelTier.LOW: os.getenv("OPENAI_MODEL_LOW", "gpt-4o-mini"),
+        ModelTier.HIGH: os.getenv("OPENAI_MODEL_HIGH", "gpt-4.1"),
+        ModelTier.ANALYST: os.getenv("OPENAI_MODEL_ANALYST", "gpt-4.1"),
+        ModelTier.OUTLINE: os.getenv("OPENAI_MODEL_OUTLINE", "gpt-4.1"),
+        ModelTier.TEXT: os.getenv("OPENAI_MODEL_TEXT", "gpt-4.1"),
+        ModelTier.CHECK_TITLE: os.getenv("OPENAI_MODEL_CHECK_TITLE", "gpt-4.1"),
+        ModelTier.TITLE_ABSTRACT: os.getenv("OPENAI_MODEL_TITLE_ABSTRACT", "gpt-4.1"),
+    },
+    LLMProvider.GEMINI: {
+        ModelTier.LOW: os.getenv("GEMINI_MODEL_LOW", "gemini-2.5-flash"),
+        ModelTier.HIGH: os.getenv("GEMINI_MODEL_HIGH", "gemini-2.5-pro"),
+        ModelTier.ANALYST: os.getenv("GEMINI_MODEL_ANALYST", "gemini-2.5-pro"),
+        ModelTier.OUTLINE: os.getenv("GEMINI_MODEL_OUTLINE", "gemini-2.5-pro"),
+        ModelTier.TEXT: os.getenv("GEMINI_MODEL_TEXT", "gemini-2.5-pro"),
+        ModelTier.CHECK_TITLE: os.getenv(
+            "GEMINI_MODEL_CHECK_TITLE", "gemini-2.5-flash"
+        ),
+        ModelTier.TITLE_ABSTRACT: os.getenv(
+            "GEMINI_MODEL_TITLE_ABSTRACT", "gemini-2.5-flash"
+        ),
+    },
+    LLMProvider.MISTRAL: {
+        ModelTier.LOW: os.getenv("MISTRAL_MODEL_LOW", "mistral-small-latest"),
+        ModelTier.HIGH: os.getenv("MISTRAL_MODEL_HIGH", "mistral-large-latest"),
+        ModelTier.ANALYST: os.getenv("MISTRAL_MODEL_ANALYST", "mistral-large-latest"),
+        ModelTier.OUTLINE: os.getenv("MISTRAL_MODEL_OUTLINE", "mistral-large-latest"),
+        ModelTier.TEXT: os.getenv("MISTRAL_MODEL_TEXT", "mistral-large-latest"),
+        ModelTier.CHECK_TITLE: os.getenv(
+            "MISTRAL_MODEL_CHECK_TITLE", "mistral-small-latest"
+        ),
+        ModelTier.TITLE_ABSTRACT: os.getenv(
+            "MISTRAL_MODEL_TITLE_ABSTRACT", "mistral-small-latest"
+        ),
+    },
+}
+
+# ---------------------------------------------------------------------------
+# API key helpers — SecretStr prevents leakage in logs / repr / tracebacks
+# ---------------------------------------------------------------------------
 
 
-def default_llm() -> ChatOpenAI:
-    # the default is used at:
-    # llm_IsLanguageNode
-    # llm_TranslateQuestionNode
-    # ...
+def _load_secret(env_var: str) -> SecretStr | None:
+    value = os.getenv(env_var)
+    return SecretStr(value) if value else None
+
+
+OPENAI_API_KEY: SecretStr | None = _load_secret("OPENAI_API_KEY")
+GEMINI_API_KEY: SecretStr | None = _load_secret("GEMINI_API_KEY")
+MISTRAL_API_KEY: SecretStr | None = _load_secret("MISTRAL_API_KEY")
+
+# ---------------------------------------------------------------------------
+# Active provider resolution
+# ---------------------------------------------------------------------------
+
+DEFAULT_PROVIDER: LLMProvider = LLMProvider(
+    os.getenv("PROVIDER", LLMProvider.OPENAI.value).lower()
+)
+
+
+def _resolve_provider(step_env_var: str) -> LLMProvider:
+    raw = os.getenv(step_env_var, DEFAULT_PROVIDER.value).lower()
+    return LLMProvider(raw)
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+
+def create_llm(provider: LLMProvider, tier: ModelTier) -> BaseChatModel:
+    """Return a ``BaseChatModel`` for *provider* at *tier*.
+
+    Provider-specific packages are imported lazily so that only the package
+    for the active provider needs to be installed.
+
+    Raises:
+        ValueError: For an unrecognised *provider*.
+    """
+    model_name = MODEL_REGISTRY[provider][tier]
+    if provider == LLMProvider.OPENAI:
+        from langchain_openai import ChatOpenAI
+
+        kwargs: dict = {"model": model_name}
+        if OPENAI_API_KEY:
+            kwargs["api_key"] = OPENAI_API_KEY.get_secret_value()
+        return ChatOpenAI(**kwargs)
+    if provider == LLMProvider.GEMINI:
+        from langchain_google_genai import ChatGoogleGenerativeAI
+
+        kwargs = {"model": model_name}
+        if GEMINI_API_KEY:
+            kwargs["google_api_key"] = GEMINI_API_KEY.get_secret_value()
+        return ChatGoogleGenerativeAI(**kwargs)
+    if provider == LLMProvider.MISTRAL:
+        from langchain_mistralai import ChatMistralAI
+
+        kwargs = {"model": model_name}
+        if MISTRAL_API_KEY:
+            kwargs["mistral_api_key"] = MISTRAL_API_KEY.get_secret_value()
+        return ChatMistralAI(**kwargs)
+    raise ValueError(f"Unsupported provider: {provider!r}")
+
+
+# ---------------------------------------------------------------------------
+# Backward-compatible public aliases
+# ---------------------------------------------------------------------------
+
+
+def get_llm_low() -> BaseChatModel:
+    return create_llm(_resolve_provider("LOW_PROVIDER"), ModelTier.LOW)
+
+
+def get_llm_high() -> BaseChatModel:
+    return create_llm(_resolve_provider("HIGH_PROVIDER"), ModelTier.HIGH)
+
+
+def default_llm() -> BaseChatModel:
     return get_llm_low()
 
 
-def llm_analyst() -> ChatOpenAI:
-    return get_llm_high()
+def llm_analyst() -> BaseChatModel:
+    return create_llm(_resolve_provider("ANALYST_PROVIDER"), ModelTier.ANALYST)
 
 
-def llm_outline() -> ChatOpenAI:
-    return get_llm_high()
+def llm_outline() -> BaseChatModel:
+    return create_llm(_resolve_provider("OUTLINE_PROVIDER"), ModelTier.OUTLINE)
 
 
-def llm_text() -> ChatOpenAI:
-    return get_llm_high()
+def llm_text() -> BaseChatModel:
+    return create_llm(_resolve_provider("TEXT_PROVIDER"), ModelTier.TEXT)
 
 
-def llm_check_title() -> ChatOpenAI:
-    return get_llm_high()
+def llm_check_title() -> BaseChatModel:
+    return create_llm(_resolve_provider("CHECK_TITLE_PROVIDER"), ModelTier.CHECK_TITLE)
 
 
-def llm_title_abstract() -> ChatOpenAI:
-    return get_llm_high()
+def llm_title_abstract() -> BaseChatModel:
+    return create_llm(
+        _resolve_provider("TITLE_ABSTRACT_PROVIDER"), ModelTier.TITLE_ABSTRACT
+    )

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -24,9 +24,7 @@ class TestLibraryStructure(unittest.TestCase):
 
             self.assertTrue(hasattr(black_langcube, "__version__"))
             self.assertTrue(hasattr(black_langcube, "__description__"))
-            pyproject = tomllib.loads(
-                (project_root / "pyproject.toml").read_text()
-            )
+            pyproject = tomllib.loads((project_root / "pyproject.toml").read_text())
             expected_version = pyproject["project"]["version"]
             self.assertEqual(black_langcube.__version__, expected_version)
         except ImportError as e:

--- a/tests/test_llm_model.py
+++ b/tests/test_llm_model.py
@@ -1,0 +1,462 @@
+"""
+Unit tests for the multi-provider LLM factory in llm_modules/llm_model.py.
+
+All tests run without a real API key — constructors are mocked and
+os.environ is patched where needed.
+"""
+
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from pydantic import SecretStr
+
+# Add the src directory to the path for testing
+project_root = Path(__file__).parent.parent
+src_path = project_root / "src"
+sys.path.insert(0, str(src_path))
+
+from black_langcube.llm_modules.llm_model import (  # noqa: E402
+    DEFAULT_PROVIDER,
+    GEMINI_API_KEY,
+    MISTRAL_API_KEY,
+    MODEL_REGISTRY,
+    OPENAI_API_KEY,
+    LLMProvider,
+    ModelTier,
+    _load_secret,
+    _resolve_provider,
+    create_llm,
+    default_llm,
+    get_llm_high,
+    get_llm_low,
+    llm_analyst,
+    llm_check_title,
+    llm_outline,
+    llm_text,
+    llm_title_abstract,
+)
+import black_langcube.llm_modules.llm_model as llm_model_module  # noqa: E402
+
+
+class TestLLMProviderEnum(unittest.TestCase):
+    """LLMProvider is a string enum with the expected members."""
+
+    def test_provider_values(self):
+        self.assertEqual(LLMProvider.OPENAI.value, "openai")
+        self.assertEqual(LLMProvider.GEMINI.value, "gemini")
+        self.assertEqual(LLMProvider.MISTRAL.value, "mistral")
+
+    def test_provider_is_string(self):
+        self.assertIsInstance(LLMProvider.OPENAI, str)
+        self.assertIsInstance(LLMProvider.GEMINI, str)
+
+    def test_provider_from_string(self):
+        self.assertEqual(LLMProvider("openai"), LLMProvider.OPENAI)
+        self.assertEqual(LLMProvider("gemini"), LLMProvider.GEMINI)
+
+
+class TestModelTierEnum(unittest.TestCase):
+    """ModelTier is a string enum covering all pipeline steps."""
+
+    def test_tier_values(self):
+        self.assertEqual(ModelTier.LOW.value, "low")
+        self.assertEqual(ModelTier.HIGH.value, "high")
+        self.assertEqual(ModelTier.ANALYST.value, "analyst")
+        self.assertEqual(ModelTier.OUTLINE.value, "outline")
+        self.assertEqual(ModelTier.TEXT.value, "text")
+        self.assertEqual(ModelTier.CHECK_TITLE.value, "check_title")
+        self.assertEqual(ModelTier.TITLE_ABSTRACT.value, "title_abstract")
+
+    def test_tier_is_string(self):
+        for tier in ModelTier:
+            self.assertIsInstance(tier, str)
+
+
+class TestModelRegistry(unittest.TestCase):
+    """MODEL_REGISTRY covers every (provider, tier) combination."""
+
+    def test_registry_has_all_providers_and_tiers(self):
+        for provider in LLMProvider:
+            self.assertIn(provider, MODEL_REGISTRY)
+            for tier in ModelTier:
+                self.assertIn(tier, MODEL_REGISTRY[provider])
+                self.assertIsInstance(MODEL_REGISTRY[provider][tier], str)
+                self.assertTrue(MODEL_REGISTRY[provider][tier])  # non-empty
+
+    def test_openai_low_default(self):
+        expected = os.getenv("OPENAI_MODEL_LOW", "gpt-4o-mini")
+        self.assertEqual(MODEL_REGISTRY[LLMProvider.OPENAI][ModelTier.LOW], expected)
+
+    def test_gemini_low_default(self):
+        expected = os.getenv("GEMINI_MODEL_LOW", "gemini-2.5-flash")
+        self.assertEqual(MODEL_REGISTRY[LLMProvider.GEMINI][ModelTier.LOW], expected)
+
+    def test_gemini_high_default(self):
+        expected = os.getenv("GEMINI_MODEL_HIGH", "gemini-2.5-pro")
+        self.assertEqual(MODEL_REGISTRY[LLMProvider.GEMINI][ModelTier.HIGH], expected)
+
+
+class TestLoadSecret(unittest.TestCase):
+    """_load_secret() wraps env vars in SecretStr or returns None."""
+
+    _ABSENT_VAR = "DEFINITELY_NOT_SET_84f7a3b2_BLCTEST"
+
+    def test_returns_none_when_not_set(self):
+        with patch.dict(os.environ, {self._ABSENT_VAR: ""}, clear=False):
+            # ensure the var is absent (not just empty)
+            os.environ.pop(self._ABSENT_VAR, None)
+            result = _load_secret(self._ABSENT_VAR)
+        self.assertIsNone(result)
+
+    def test_returns_secretstr_when_set(self):
+        with patch.dict(os.environ, {"BLC_TEST_KEY": "my-test-key"}):
+            result = _load_secret("BLC_TEST_KEY")
+        self.assertIsInstance(result, SecretStr)
+        self.assertEqual(result.get_secret_value(), "my-test-key")
+
+    def test_returns_none_for_empty_string(self):
+        with patch.dict(os.environ, {"BLC_TEST_KEY": ""}):
+            result = _load_secret("BLC_TEST_KEY")
+        self.assertIsNone(result)
+
+
+class TestSecretStrLeakPrevention(unittest.TestCase):
+    """SecretStr does not expose the raw value in repr / str / f-strings."""
+
+    def _make_secret(self) -> SecretStr:
+        return SecretStr("super-secret-api-key-12345")
+
+    def test_repr_does_not_contain_value(self):
+        secret = self._make_secret()
+        self.assertNotIn("super-secret-api-key-12345", repr(secret))
+
+    def test_str_does_not_contain_value(self):
+        secret = self._make_secret()
+        self.assertNotIn("super-secret-api-key-12345", str(secret))
+
+    def test_fstring_does_not_contain_value(self):
+        secret = self._make_secret()
+        self.assertNotIn("super-secret-api-key-12345", f"{secret}")
+
+    def test_get_secret_value_returns_raw(self):
+        secret = self._make_secret()
+        self.assertEqual(secret.get_secret_value(), "super-secret-api-key-12345")
+
+    def test_module_openai_key_is_secretstr_or_none(self):
+        """OPENAI_API_KEY is either a SecretStr or None — never a plain str."""
+        self.assertIsInstance(OPENAI_API_KEY, (SecretStr, type(None)))
+
+    def test_module_gemini_key_is_secretstr_or_none(self):
+        self.assertIsInstance(GEMINI_API_KEY, (SecretStr, type(None)))
+
+    def test_module_mistral_key_is_secretstr_or_none(self):
+        self.assertIsInstance(MISTRAL_API_KEY, (SecretStr, type(None)))
+
+
+class TestCreateLLMOpenAI(unittest.TestCase):
+    """create_llm() dispatches to ChatOpenAI with the correct model name."""
+
+    def _call_and_get_kwargs(self, tier: ModelTier) -> dict:
+        with patch("langchain_openai.ChatOpenAI") as mock_cls:
+            create_llm(LLMProvider.OPENAI, tier)
+            return mock_cls.call_args.kwargs
+
+    def test_openai_low_uses_correct_model(self):
+        kwargs = self._call_and_get_kwargs(ModelTier.LOW)
+        self.assertEqual(
+            kwargs["model"], MODEL_REGISTRY[LLMProvider.OPENAI][ModelTier.LOW]
+        )
+
+    def test_openai_high_uses_correct_model(self):
+        kwargs = self._call_and_get_kwargs(ModelTier.HIGH)
+        self.assertEqual(
+            kwargs["model"], MODEL_REGISTRY[LLMProvider.OPENAI][ModelTier.HIGH]
+        )
+
+    def test_openai_analyst_uses_correct_model(self):
+        kwargs = self._call_and_get_kwargs(ModelTier.ANALYST)
+        self.assertEqual(
+            kwargs["model"], MODEL_REGISTRY[LLMProvider.OPENAI][ModelTier.ANALYST]
+        )
+
+    def test_openai_passes_api_key(self):
+        """When OPENAI_API_KEY is set, its value is forwarded to ChatOpenAI."""
+        secret = SecretStr("test-openai-key")
+        with patch.object(llm_model_module, "OPENAI_API_KEY", secret):
+            with patch("langchain_openai.ChatOpenAI") as mock_cls:
+                create_llm(LLMProvider.OPENAI, ModelTier.LOW)
+                kwargs = mock_cls.call_args.kwargs
+        self.assertEqual(kwargs["api_key"], "test-openai-key")
+
+    def test_openai_omits_api_key_when_none(self):
+        with patch.object(llm_model_module, "OPENAI_API_KEY", None):
+            with patch("langchain_openai.ChatOpenAI") as mock_cls:
+                create_llm(LLMProvider.OPENAI, ModelTier.LOW)
+                kwargs = mock_cls.call_args.kwargs
+        self.assertNotIn("api_key", kwargs)
+
+
+class TestCreateLLMGemini(unittest.TestCase):
+    """create_llm() dispatches to ChatGoogleGenerativeAI with correct model name."""
+
+    def _mock_gemini_module(self) -> MagicMock:
+        mock_mod = MagicMock()
+        return mock_mod
+
+    def test_gemini_low_uses_correct_model(self):
+        mock_mod = self._mock_gemini_module()
+        with patch.dict("sys.modules", {"langchain_google_genai": mock_mod}):
+            create_llm(LLMProvider.GEMINI, ModelTier.LOW)
+            kwargs = mock_mod.ChatGoogleGenerativeAI.call_args.kwargs
+        self.assertEqual(
+            kwargs["model"], MODEL_REGISTRY[LLMProvider.GEMINI][ModelTier.LOW]
+        )
+
+    def test_gemini_high_uses_correct_model(self):
+        mock_mod = self._mock_gemini_module()
+        with patch.dict("sys.modules", {"langchain_google_genai": mock_mod}):
+            create_llm(LLMProvider.GEMINI, ModelTier.HIGH)
+            kwargs = mock_mod.ChatGoogleGenerativeAI.call_args.kwargs
+        self.assertEqual(
+            kwargs["model"], MODEL_REGISTRY[LLMProvider.GEMINI][ModelTier.HIGH]
+        )
+
+    def test_gemini_passes_api_key(self):
+        secret = SecretStr("test-gemini-key")
+        mock_mod = self._mock_gemini_module()
+        with patch.object(llm_model_module, "GEMINI_API_KEY", secret):
+            with patch.dict("sys.modules", {"langchain_google_genai": mock_mod}):
+                create_llm(LLMProvider.GEMINI, ModelTier.LOW)
+                kwargs = mock_mod.ChatGoogleGenerativeAI.call_args.kwargs
+        self.assertEqual(kwargs["google_api_key"], "test-gemini-key")
+
+    def test_gemini_omits_google_api_key_when_none(self):
+        mock_mod = self._mock_gemini_module()
+        with patch.object(llm_model_module, "GEMINI_API_KEY", None):
+            with patch.dict("sys.modules", {"langchain_google_genai": mock_mod}):
+                create_llm(LLMProvider.GEMINI, ModelTier.LOW)
+                kwargs = mock_mod.ChatGoogleGenerativeAI.call_args.kwargs
+        self.assertNotIn("google_api_key", kwargs)
+
+
+class TestCreateLLMUnknownProvider(unittest.TestCase):
+    """create_llm() raises ValueError for unsupported providers."""
+
+    def test_invalid_string_raises(self):
+        """Non-enum values cause a ValueError or KeyError before factory dispatch."""
+        with self.assertRaises((ValueError, KeyError)):
+            create_llm("unknown_provider", ModelTier.LOW)  # type: ignore[arg-type]
+
+
+class TestCreateLLMMistral(unittest.TestCase):
+    """create_llm() dispatches to ChatMistralAI with the correct model name."""
+
+    def _mock_mistral_module(self) -> MagicMock:
+        return MagicMock()
+
+    def test_mistral_low_uses_correct_model(self):
+        mock_mod = self._mock_mistral_module()
+        with patch.dict("sys.modules", {"langchain_mistralai": mock_mod}):
+            create_llm(LLMProvider.MISTRAL, ModelTier.LOW)
+            kwargs = mock_mod.ChatMistralAI.call_args.kwargs
+        self.assertEqual(
+            kwargs["model"], MODEL_REGISTRY[LLMProvider.MISTRAL][ModelTier.LOW]
+        )
+
+    def test_mistral_high_uses_correct_model(self):
+        mock_mod = self._mock_mistral_module()
+        with patch.dict("sys.modules", {"langchain_mistralai": mock_mod}):
+            create_llm(LLMProvider.MISTRAL, ModelTier.HIGH)
+            kwargs = mock_mod.ChatMistralAI.call_args.kwargs
+        self.assertEqual(
+            kwargs["model"], MODEL_REGISTRY[LLMProvider.MISTRAL][ModelTier.HIGH]
+        )
+
+    def test_mistral_passes_api_key(self):
+        secret = SecretStr("test-mistral-key")
+        mock_mod = self._mock_mistral_module()
+        with patch.object(llm_model_module, "MISTRAL_API_KEY", secret):
+            with patch.dict("sys.modules", {"langchain_mistralai": mock_mod}):
+                create_llm(LLMProvider.MISTRAL, ModelTier.LOW)
+                kwargs = mock_mod.ChatMistralAI.call_args.kwargs
+        self.assertEqual(kwargs["mistral_api_key"], "test-mistral-key")
+
+    def test_mistral_omits_api_key_when_none(self):
+        mock_mod = self._mock_mistral_module()
+        with patch.object(llm_model_module, "MISTRAL_API_KEY", None):
+            with patch.dict("sys.modules", {"langchain_mistralai": mock_mod}):
+                create_llm(LLMProvider.MISTRAL, ModelTier.LOW)
+                kwargs = mock_mod.ChatMistralAI.call_args.kwargs
+        self.assertNotIn("mistral_api_key", kwargs)
+
+
+class TestCreateLLMAllTiers(unittest.TestCase):
+    """create_llm() dispatches without error for every (provider, tier) combination."""
+
+    def test_all_provider_tier_combinations_dispatch(self):
+        """No (provider, tier) pair raises an exception."""
+        openai_mock = MagicMock()
+        gemini_mock = MagicMock()
+        mistral_mock = MagicMock()
+        sys_modules_patch = {
+            "langchain_openai": openai_mock,
+            "langchain_google_genai": gemini_mock,
+            "langchain_mistralai": mistral_mock,
+        }
+        with patch.dict("sys.modules", sys_modules_patch):
+            for provider in LLMProvider:
+                for tier in ModelTier:
+                    with self.subTest(provider=provider, tier=tier):
+                        create_llm(provider, tier)  # must not raise
+
+    def test_all_combinations_use_registry_model_name(self):
+        """create_llm() always passes the MODEL_REGISTRY name as the 'model' kwarg."""
+        openai_mock = MagicMock()
+        gemini_mock = MagicMock()
+        mistral_mock = MagicMock()
+        constructor_map = {
+            LLMProvider.OPENAI: openai_mock.ChatOpenAI,
+            LLMProvider.GEMINI: gemini_mock.ChatGoogleGenerativeAI,
+            LLMProvider.MISTRAL: mistral_mock.ChatMistralAI,
+        }
+        sys_modules_patch = {
+            "langchain_openai": openai_mock,
+            "langchain_google_genai": gemini_mock,
+            "langchain_mistralai": mistral_mock,
+        }
+        with patch.dict("sys.modules", sys_modules_patch):
+            for provider in LLMProvider:
+                for tier in ModelTier:
+                    constructor_map[provider].reset_mock()
+                    with self.subTest(provider=provider, tier=tier):
+                        create_llm(provider, tier)
+                        kwargs = constructor_map[provider].call_args.kwargs
+                        self.assertEqual(
+                            kwargs["model"], MODEL_REGISTRY[provider][tier]
+                        )
+
+
+class TestResolveProvider(unittest.TestCase):
+    """_resolve_provider() reads step env var and falls back to DEFAULT_PROVIDER."""
+
+    _ABSENT_VAR = "DEFINITELY_NOT_SET_STEP_84f7a3b2_BLCTEST"
+
+    def test_returns_llm_provider_instance(self):
+        result = _resolve_provider(self._ABSENT_VAR)
+        self.assertIsInstance(result, LLMProvider)
+
+    def test_reads_step_env_var(self):
+        with patch.dict(os.environ, {"BLC_TEST_STEP_PROVIDER": "gemini"}):
+            result = _resolve_provider("BLC_TEST_STEP_PROVIDER")
+        self.assertEqual(result, LLMProvider.GEMINI)
+
+    def test_reads_openai_from_env_var(self):
+        with patch.dict(os.environ, {"BLC_TEST_STEP_PROVIDER": "openai"}):
+            result = _resolve_provider("BLC_TEST_STEP_PROVIDER")
+        self.assertEqual(result, LLMProvider.OPENAI)
+
+    def test_invalid_env_var_value_raises_value_error(self):
+        with patch.dict(os.environ, {"BLC_TEST_STEP_PROVIDER": "invalid_provider_xyz"}):
+            with self.assertRaises(ValueError):
+                _resolve_provider("BLC_TEST_STEP_PROVIDER")
+
+    def test_default_provider_is_llm_provider(self):
+        self.assertIsInstance(DEFAULT_PROVIDER, LLMProvider)
+
+
+class TestGlobalProviderOverride(unittest.TestCase):
+    """Setting PROVIDER env var switches the default provider for all tiers."""
+
+    _ABSENT_STEP_VAR = "DEFINITELY_NOT_SET_STEP_84f7a3b2_BLCTEST"
+
+    def test_global_provider_gemini_is_default_when_patched(self):
+        """When DEFAULT_PROVIDER is GEMINI, unset step vars resolve to GEMINI."""
+        with patch.object(llm_model_module, "DEFAULT_PROVIDER", LLMProvider.GEMINI):
+            result = _resolve_provider(self._ABSENT_STEP_VAR)
+        self.assertEqual(result, LLMProvider.GEMINI)
+
+    def test_global_provider_openai_is_default_when_patched(self):
+        """When DEFAULT_PROVIDER is OPENAI, unset step vars resolve to OPENAI."""
+        with patch.object(llm_model_module, "DEFAULT_PROVIDER", LLMProvider.OPENAI):
+            result = _resolve_provider(self._ABSENT_STEP_VAR)
+        self.assertEqual(result, LLMProvider.OPENAI)
+
+    def test_global_provider_mistral_is_default_when_patched(self):
+        """When DEFAULT_PROVIDER is MISTRAL, unset step vars resolve to MISTRAL."""
+        with patch.object(llm_model_module, "DEFAULT_PROVIDER", LLMProvider.MISTRAL):
+            result = _resolve_provider(self._ABSENT_STEP_VAR)
+        self.assertEqual(result, LLMProvider.MISTRAL)
+
+    def test_step_override_takes_precedence_over_global(self):
+        """An explicit step env var overrides DEFAULT_PROVIDER."""
+        with patch.object(llm_model_module, "DEFAULT_PROVIDER", LLMProvider.GEMINI):
+            with patch.dict(os.environ, {"BLC_TEST_STEP_PROVIDER": "openai"}):
+                result = _resolve_provider("BLC_TEST_STEP_PROVIDER")
+        self.assertEqual(result, LLMProvider.OPENAI)
+
+
+class TestPublicAliases(unittest.TestCase):
+    """Public alias functions delegate to create_llm() with the expected tier."""
+
+    def _assert_tier(self, fn, expected_tier: ModelTier) -> None:
+        with patch.object(llm_model_module, "create_llm") as mock_create:
+            fn()
+            args = mock_create.call_args[0]
+            self.assertEqual(args[1], expected_tier)
+
+    def test_get_llm_low_delegates_to_low_tier(self):
+        self._assert_tier(get_llm_low, ModelTier.LOW)
+
+    def test_get_llm_high_delegates_to_high_tier(self):
+        self._assert_tier(get_llm_high, ModelTier.HIGH)
+
+    def test_llm_analyst_delegates_to_analyst_tier(self):
+        self._assert_tier(llm_analyst, ModelTier.ANALYST)
+
+    def test_llm_outline_delegates_to_outline_tier(self):
+        self._assert_tier(llm_outline, ModelTier.OUTLINE)
+
+    def test_llm_text_delegates_to_text_tier(self):
+        self._assert_tier(llm_text, ModelTier.TEXT)
+
+    def test_llm_check_title_delegates_to_check_title_tier(self):
+        self._assert_tier(llm_check_title, ModelTier.CHECK_TITLE)
+
+    def test_llm_title_abstract_delegates_to_title_abstract_tier(self):
+        self._assert_tier(llm_title_abstract, ModelTier.TITLE_ABSTRACT)
+
+    def test_default_llm_calls_get_llm_low(self):
+        with patch.object(llm_model_module, "get_llm_low") as mock_low:
+            default_llm()
+            mock_low.assert_called_once()
+
+
+class TestPublicAPIExports(unittest.TestCase):
+    """LLMProvider and ModelTier are exported from the top-level package."""
+
+    def test_llm_provider_importable_from_package(self):
+        from black_langcube import LLMProvider as LP
+
+        self.assertIs(LP, LLMProvider)
+
+    def test_model_tier_importable_from_package(self):
+        from black_langcube import ModelTier as MT
+
+        self.assertIs(MT, ModelTier)
+
+    def test_llm_provider_in_all(self):
+        import black_langcube
+
+        self.assertIn("LLMProvider", black_langcube.__all__)
+
+    def test_model_tier_in_all(self):
+        import black_langcube
+
+        self.assertIn("ModelTier", black_langcube.__all__)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
…ection

- Introduce LLMProvider (openai/gemini/mistral) and ModelTier string enums
- Add MODEL_REGISTRY: env-var-driven (provider, tier) → model name mapping
- Implement create_llm() factory with lazy provider-package imports
- Wrap all API keys in pydantic SecretStr; omit kwarg entirely when key is absent
- Wire Mistral via ChatMistralAI with real model name defaults (mistral-small-latest / mistral-large-latest)
- Rewrite public aliases (get_llm_low, llm_analyst, …) as thin wrappers
- Export LLMProvider and ModelTier from the top-level package
- Add langchain-google-genai>=2 and langchain-mistralai>=0.2 as optional deps
- Add 56 unit tests: enum values, registry completeness, SecretStr non-leakage, full (provider, tier) dispatch coverage, global/per-step provider override, and alias delegation; all pass without a real API key
- Bump version 0.3.2 → 0.3.3; update CHANGELOG