### PR TITLE
feat: constructor-level LLM dependency injection (BP-10)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.3.4] - 2026-04-06
+
+### Feature: constructor-level LLM dependency injection
+
+- Modified `LLMNode.__init__` to accept an optional `llm` parameter (`llm=None`); when omitted or `None`, `default_llm()` is called once at construction time and stored as `self.llm` — no factory call is ever made after construction
+- Changed `LLMNode.get_llm()` to return `self.llm` directly; it no longer calls any factory function on each invocation, eliminating implicit coupling to module-level singletons
+- Replaced the `from black_langcube.llm_modules.llm_model import get_llm_low` import in `LLMNode.py` with `from black_langcube.llm_modules.llm_model import default_llm`
+- Updated `TranslatorEngNode.__init__` and `TranslatorUsrNode.__init__` to accept `llm=None` and forward it via `super().__init__(state, config, llm=llm)`; `get_llm()` overrides removed
+- Updated `TextAnalyzerNode`, `SummaryExtractorNode`, and `SentimentExtractorNode` in `examples/custom_llm_node.py` with explicit `__init__(self, state, config, llm=None)` forwarding to `super()`
+- Made `build_graph()` in `TranslatorEnSubgraf`, `TranslatorUsrSubgraf`, and `MessageTranslatorSubgraf` the single LLM injection site: one `default_llm()` call at the top of each method, passed via `llm=` to every node constructor; `default_llm` import is deferred inside `build_graph()` to avoid circular imports
+- Made `TextAnalysisWorkflow.build_graph()` in `examples/custom_llm_node.py` the single injection site for all three node types
+- Confirmed that module-level `_llm_low` / `_llm_high` cached globals no longer exist in `llm_model.py` (removed in v0.2.2); no external code depends on them
+- Added `tests/test_llm_node_injection.py` with 13 tests: `LLMNode` injection mechanics (stored attribute, `get_llm()` return identity, `None` fallback via mocked `default_llm`, two-node isolation), `TranslatorEngNode.execute()` with `FakeListChatModel` (correct output, no factory call), `TranslatorUsrNode.execute()` with `FakeListChatModel` (correct output, no factory call), and singleton-isolation tests across node types; all tests run with no API key and no network call
+- Used `langchain_core.language_models.fake_chat_models.FakeListChatModel` for deterministic test responses (no extra dependency); this is a private submodule — re-evaluate when langchain-core exposes a stable public re-export
+- Updated `CheckTitleRelevance(title, topic, llm=None)` to accept an optional `llm` parameter; falls back to `default_llm()` when `None`; replaced the `get_llm_low` import with `default_llm`
+- All 113 tests pass
+
 ## [0.3.3] - 2026-04-06
 ### Feature: multi-provider LLM factory with SecretStr API key protection
 - Introduced `LLMProvider` (string enum: `OPENAI`, `GEMINI`, `MISTRAL`) and `ModelTier` (string enum: `LOW`, `HIGH`, `ANALYST`, `OUTLINE`, `TEXT`, `CHECK_TITLE`, `TITLE_ABSTRACT`) in `llm_modules/llm_model.py`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "black_langcube"
-version = "0.3.3"
+version = "0.3.4"
 description = "A LangGraph-based extension framework for complex workflow applications, enabling the integration of various AI models and tools into a cohesive system."
 readme = "README.md"
 license = "MIT"

--- a/src/black_langcube/__init__.py
+++ b/src/black_langcube/__init__.py
@@ -2,7 +2,7 @@
 Black LangCube - A framework for building LLM applications with LangGraph.
 """
 
-__version__ = "0.3.3"
+__version__ = "0.3.4"
 __description__ = "A framework for building LLM applications with LangGraph"
 
 # Import core components to make them available from the main package

--- a/src/black_langcube/examples/custom_llm_node.py
+++ b/src/black_langcube/examples/custom_llm_node.py
@@ -48,6 +48,9 @@ class TextAnalyzerNode(LLMNode):
     Custom LLM node for analyzing text sentiment and extracting key information.
     """
 
+    def __init__(self, state, config, llm=None):
+        super().__init__(state, config, llm=llm)
+
     def generate_messages(self):
         """Generate messages for the LLM."""
         text = self.state.get("input_text", "")
@@ -91,6 +94,9 @@ class SummaryExtractorNode(LLMNode):
     Custom node to extract a concise summary from the analysis.
     """
 
+    def __init__(self, state, config, llm=None):
+        super().__init__(state, config, llm=llm)
+
     def generate_messages(self):
         """Generate messages for summary extraction."""
         analysis = self.state.get("analysis_result", {})
@@ -121,6 +127,9 @@ class SentimentExtractorNode(LLMNode):
     """
     Custom node to extract sentiment classification.
     """
+
+    def __init__(self, state, config, llm=None):
+        super().__init__(state, config, llm=llm)
 
     def generate_messages(self):
         """Generate messages for sentiment extraction."""
@@ -178,13 +187,18 @@ class TextAnalysisWorkflow(BaseGraph):
 
     def build_graph(self):
         """Build the text analysis workflow."""
+        from black_langcube.llm_modules.llm_model import default_llm
+
         logger = logging.getLogger(__name__)
         logger.info("Building text analysis workflow graph...")
 
+        # One LLM instance for this graph — injected into every node
+        low_llm = default_llm()
+
         # Create custom node instances
-        analyzer_node = TextAnalyzerNode(self.state, {})
-        summary_node = SummaryExtractorNode(self.state, {})
-        sentiment_node = SentimentExtractorNode(self.state, {})
+        analyzer_node = TextAnalyzerNode(self.state, {}, llm=low_llm)
+        summary_node = SummaryExtractorNode(self.state, {}, llm=low_llm)
+        sentiment_node = SentimentExtractorNode(self.state, {}, llm=low_llm)
 
         logger.info("Created custom LLM node instances")
 

--- a/src/black_langcube/graf/subgrafs/message_translator_subgraf.py
+++ b/src/black_langcube/graf/subgrafs/message_translator_subgraf.py
@@ -57,8 +57,13 @@ class MessageTranslatorSubgraf(
         self.build_graph()
 
     def build_graph(self):
+        from black_langcube.llm_modules.llm_model import default_llm
+
+        low_llm = default_llm()
         # Instantiate the workflow nodes
-        TranslatorUsrNode_instance = TranslatorUsrNode(self.state, self.config)
+        TranslatorUsrNode_instance = TranslatorUsrNode(
+            self.state, self.config, llm=low_llm
+        )
         # Add the TranslatorUsrNode to the graph
         self.add_node("translator_usr", TranslatorUsrNode_instance.execute)
 

--- a/src/black_langcube/graf/subgrafs/translator_en_subgraf.py
+++ b/src/black_langcube/graf/subgrafs/translator_en_subgraf.py
@@ -58,8 +58,13 @@ class TranslatorEnSubgraf(
         self.build_graph()
 
     def build_graph(self):
+        from black_langcube.llm_modules.llm_model import default_llm
+
+        low_llm = default_llm()
         # Instantiate the workflow nodes
-        TranslatorEngNode_instance = TranslatorEngNode(self.state, self.config)
+        TranslatorEngNode_instance = TranslatorEngNode(
+            self.state, self.config, llm=low_llm
+        )
         # Add the TranslatorEngNode to the graph
         self.add_node("translator_en", TranslatorEngNode_instance.execute)
 

--- a/src/black_langcube/graf/subgrafs/translator_usr_subgraf.py
+++ b/src/black_langcube/graf/subgrafs/translator_usr_subgraf.py
@@ -58,8 +58,13 @@ class TranslatorUsrSubgraf(
         self.build_graph()
 
     def build_graph(self):
+        from black_langcube.llm_modules.llm_model import default_llm
+
+        low_llm = default_llm()
         # Instantiate the workflow nodes
-        TranslatorUsrNode_instance = TranslatorUsrNode(self.state, self.config)
+        TranslatorUsrNode_instance = TranslatorUsrNode(
+            self.state, self.config, llm=low_llm
+        )
         # Add the TranslatorUsrNode to the graph
         self.add_node("translator_usr", TranslatorUsrNode_instance.execute)
 

--- a/src/black_langcube/llm_modules/CheckTitleRelevance.py
+++ b/src/black_langcube/llm_modules/CheckTitleRelevance.py
@@ -4,22 +4,25 @@ from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.output_parsers import StrOutputParser
 from langchain_community.callbacks import get_openai_callback
 
-from black_langcube.llm_modules.llm_model import get_llm_low
+from black_langcube.llm_modules.llm_model import default_llm
 
 logger = logging.getLogger(__name__)
 
 
-def CheckTitleRelevance(title, topic):
+def CheckTitleRelevance(title, topic, llm=None):
     """
     Check if the given article title is relevant to the specified topic.
 
     Args:
         title (str): The title of the article.
         topic (str): The topic to check relevance against.
+        llm (BaseChatModel | None): Language model to use. Defaults to ``default_llm()``.
 
     Returns:
         str: 'Yes' if the title is relevant to the topic, otherwise 'No'.
     """
+    model = llm if llm is not None else default_llm()
+
     messages = [
         (
             "human",
@@ -28,7 +31,7 @@ def CheckTitleRelevance(title, topic):
     ]
     prompt = ChatPromptTemplate.from_messages(messages)
 
-    chain = prompt | get_llm_low() | StrOutputParser()
+    chain = prompt | model | StrOutputParser()
 
     with get_openai_callback() as cb:
         result = chain.invoke({"title": title, "topic": topic})

--- a/src/black_langcube/llm_modules/LLMNodes/LLMNode.py
+++ b/src/black_langcube/llm_modules/LLMNodes/LLMNode.py
@@ -3,17 +3,19 @@ LLMNode is a base class for nodes that interact with language models in a chain-
 Attributes:
     state (Any): The current state or context for the node.
     config (Any): Configuration parameters for the node.
+    llm (BaseChatModel): The language model instance injected at construction time.
     logger (logging.Logger): Logger instance for the node.
 Methods:
-    __init__(state, config):
-        Initializes the LLMNode with the given state and configuration.
+    __init__(state, config, llm=None):
+        Initializes the LLMNode with the given state, configuration, and optional LLM instance.
+        When ``llm`` is ``None``, the default LLM is created via ``default_llm()``.
     generate_messages():
         Abstract method to return a list of messages for prompt composition.
         Must be implemented by subclasses.
     get_llm():
-        Returns the language model instance to use. Can be overridden by subclasses.
+        Returns the LLM instance stored at construction time.
     get_parser():
-        Returns the output parser for the language model's response. Can be overridden by subclasses.
+        Returns the output parser for the language model's response. Can be overridden if needed.
     run_chain(extra_input=None):
         Prepares and executes the chain using the generated messages, language model, and parser.
         Returns the result and token usage.
@@ -25,14 +27,15 @@ import logging
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.output_parsers import StrOutputParser
 
-from black_langcube.llm_modules.llm_model import get_llm_low
+from black_langcube.llm_modules.llm_model import default_llm
 from black_langcube.llm_modules.robust_invoke_async import robust_invoke_async
 
 
 class LLMNode:
-    def __init__(self, state, config):
+    def __init__(self, state, config, llm=None):
         self.state = state
         self.config = config
+        self.llm = llm if llm is not None else default_llm()
         self.logger = logging.getLogger(__name__)
 
     def generate_messages(self):
@@ -41,8 +44,8 @@ class LLMNode:
         raise NotImplementedError
 
     def get_llm(self):
-        """Return the appropriate language model. Subclasses can override this if needed."""
-        return get_llm_low()  # or appropriate llm instance
+        """Return the LLM instance stored at construction time."""
+        return self.llm
 
     def get_parser(self):
         """Return the output parser. Subclasses can override if needed."""

--- a/src/black_langcube/llm_modules/LLMNodes/subgraphs/translator_en_subgraph.py
+++ b/src/black_langcube/llm_modules/LLMNodes/subgraphs/translator_en_subgraph.py
@@ -19,8 +19,8 @@ logger = logging.getLogger(__name__)
 
 
 class TranslatorEngNode(LLMNode):
-    def __init__(self, state, config):
-        super().__init__(state, config)
+    def __init__(self, state, config, llm=None):
+        super().__init__(state, config, llm=llm)
 
     def generate_messages(self):
         """

--- a/src/black_langcube/llm_modules/LLMNodes/subgraphs/translator_usr_subgraph.py
+++ b/src/black_langcube/llm_modules/LLMNodes/subgraphs/translator_usr_subgraph.py
@@ -23,8 +23,8 @@ logger = logging.getLogger(__name__)
 
 
 class TranslatorUsrNode(LLMNode):
-    def __init__(self, state, config):
-        super().__init__(state, config)
+    def __init__(self, state, config, llm=None):
+        super().__init__(state, config, llm=llm)
 
     def generate_messages(self):
         """

--- a/tests/test_llm_node_injection.py
+++ b/tests/test_llm_node_injection.py
@@ -1,0 +1,243 @@
+"""
+Unit tests for constructor-level LLM dependency injection in LLMNode.
+
+Tests verify:
+- LLM injection via ``llm=`` parameter at construction time.
+- ``get_llm()`` returns the injected instance directly.
+- ``llm=None`` falls back to ``default_llm()`` without raising.
+- Two independently constructed nodes hold different LLM instances with no shared state.
+- ``TranslatorEngNode.execute()`` and ``TranslatorUsrNode.execute()`` produce the correct
+  output when a ``FakeListChatModel`` is injected — no API key, no network call.
+"""
+
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# NOTE: FakeListChatModel lives in a private submodule (fake_chat_models) because
+# langchain-core 0.3.x does not re-export it from the public ``fake`` module.
+# Re-evaluate this import path when langchain-core adds a stable public re-export.
+from langchain_core.language_models.fake_chat_models import FakeListChatModel
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root / "src"))
+
+from black_langcube.llm_modules.LLMNodes.LLMNode import LLMNode  # noqa: E402
+from black_langcube.llm_modules.LLMNodes.subgraphs.translator_en_subgraph import (  # noqa: E402
+    TranslatorEngNode,
+)
+from black_langcube.llm_modules.LLMNodes.subgraphs.translator_usr_subgraph import (  # noqa: E402
+    TranslatorUsrNode,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _MinimalNode(LLMNode):
+    """Minimal concrete LLMNode used only in unit tests."""
+
+    def generate_messages(self):
+        return [("human", "hello")]
+
+
+def _fake_llm(responses=None):
+    return FakeListChatModel(responses=responses or ["fake response"])
+
+
+def _translator_en_state():
+    return {
+        "translation_input": "",
+        "translation_output": "",
+        "translation_tokens": {},
+        "language": "",
+        "question": "",
+        "messages": [],
+    }
+
+
+def _translator_usr_state():
+    return {
+        "translation_input": "",
+        "translation_output": "",
+        "translation_tokens": {},
+        "language": "",
+        "messages": [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests: LLMNode injection mechanics
+# ---------------------------------------------------------------------------
+
+
+class TestLLMNodeInjection(unittest.TestCase):
+    """LLM injection mechanics on the base class."""
+
+    def test_injected_llm_stored_as_instance_attribute(self):
+        """Injected llm is stored and returned by get_llm()."""
+        fake = _fake_llm()
+        node = _MinimalNode({}, {}, llm=fake)
+        self.assertIs(node.llm, fake)
+        self.assertIs(node.get_llm(), fake)
+
+    def test_get_llm_returns_stored_instance_not_factory_result(self):
+        """get_llm() never calls a factory — it returns the stored attribute."""
+        fake = _fake_llm(["response A"])
+        node = _MinimalNode({}, {}, llm=fake)
+        self.assertIs(node.get_llm(), fake)
+        self.assertIs(node.get_llm(), fake)  # same object on repeated calls
+
+    def test_two_nodes_with_different_llms_do_not_share_state(self):
+        """Two nodes constructed independently hold separate LLM instances."""
+        fake_a = _fake_llm(["A"])
+        fake_b = _fake_llm(["B"])
+        node_a = _MinimalNode({}, {}, llm=fake_a)
+        node_b = _MinimalNode({}, {}, llm=fake_b)
+        self.assertIsNot(node_a.llm, node_b.llm)
+        self.assertIs(node_a.get_llm(), fake_a)
+        self.assertIs(node_b.get_llm(), fake_b)
+
+    def test_llm_none_falls_back_to_default_llm(self):
+        """Passing llm=None triggers default_llm() without raising."""
+        sentinel = MagicMock(name="default_llm_sentinel")
+        with patch(
+            "black_langcube.llm_modules.LLMNodes.LLMNode.default_llm",
+            return_value=sentinel,
+        ):
+            node = _MinimalNode({}, {}, llm=None)
+        self.assertIs(node.llm, sentinel)
+
+    def test_omitting_llm_kwarg_falls_back_to_default_llm(self):
+        """Omitting ``llm`` entirely triggers default_llm() without raising."""
+        sentinel = MagicMock(name="default_llm_sentinel")
+        with patch(
+            "black_langcube.llm_modules.LLMNodes.LLMNode.default_llm",
+            return_value=sentinel,
+        ):
+            node = _MinimalNode({}, {})
+        self.assertIs(node.llm, sentinel)
+
+
+# ---------------------------------------------------------------------------
+# Tests: TranslatorEngNode with FakeListChatModel
+# ---------------------------------------------------------------------------
+
+
+class TestTranslatorEngNodeWithFakeLLM(unittest.IsolatedAsyncioTestCase):
+    """TranslatorEngNode.execute() produces expected output with a fake LLM."""
+
+    async def test_execute_returns_fake_translation(self):
+        state = _translator_en_state()
+        fake = _fake_llm(["Hola mundo"])
+        node = TranslatorEngNode(state, {}, llm=fake)
+        extra = {"translation_input": "Hello world", "language": "Spanish"}
+
+        result = await node.execute(extra_input=extra)
+
+        self.assertEqual(result["translation_output"], "Hola mundo")
+        self.assertEqual(result["language"], "Spanish")
+        self.assertIn("translation_tokens", result)
+
+    async def test_execute_uses_injected_llm_not_factory(self):
+        """No factory function is called during execute()."""
+        state = _translator_en_state()
+        fake = _fake_llm(["Bonjour le monde"])
+        node = TranslatorEngNode(state, {}, llm=fake)
+        extra = {"translation_input": "Hello world", "language": "French"}
+
+        with patch(
+            "black_langcube.llm_modules.LLMNodes.LLMNode.default_llm"
+        ) as mock_factory:
+            result = await node.execute(extra_input=extra)
+
+        mock_factory.assert_not_called()
+        self.assertEqual(result["translation_output"], "Bonjour le monde")
+
+    def test_injected_llm_stored_on_translator_eng_node(self):
+        fake = _fake_llm()
+        node = TranslatorEngNode(_translator_en_state(), {}, llm=fake)
+        self.assertIs(node.llm, fake)
+        self.assertIs(node.get_llm(), fake)
+
+
+# ---------------------------------------------------------------------------
+# Tests: TranslatorUsrNode with FakeListChatModel
+# ---------------------------------------------------------------------------
+
+
+class TestTranslatorUsrNodeWithFakeLLM(unittest.IsolatedAsyncioTestCase):
+    """TranslatorUsrNode.execute() produces expected output with a fake LLM."""
+
+    async def test_execute_returns_fake_translation(self):
+        state = _translator_usr_state()
+        fake = _fake_llm(["Hola usuario"])
+        node = TranslatorUsrNode(state, {}, llm=fake)
+        extra = {"translation_input": "Hello user", "language": "Spanish"}
+
+        result = await node.execute(extra_input=extra)
+
+        self.assertEqual(result["translation_output"], "Hola usuario")
+        self.assertEqual(result["language"], "Spanish")
+        self.assertIn("translation_tokens", result)
+
+    async def test_execute_uses_injected_llm_not_factory(self):
+        """No factory function is called during execute()."""
+        state = _translator_usr_state()
+        fake = _fake_llm(["Hej bruger"])
+        node = TranslatorUsrNode(state, {}, llm=fake)
+        extra = {"translation_input": "Hello user", "language": "Danish"}
+
+        with patch(
+            "black_langcube.llm_modules.LLMNodes.LLMNode.default_llm"
+        ) as mock_factory:
+            result = await node.execute(extra_input=extra)
+
+        mock_factory.assert_not_called()
+        self.assertEqual(result["translation_output"], "Hej bruger")
+
+    def test_injected_llm_stored_on_translator_usr_node(self):
+        fake = _fake_llm()
+        node = TranslatorUsrNode(_translator_usr_state(), {}, llm=fake)
+        self.assertIs(node.llm, fake)
+        self.assertIs(node.get_llm(), fake)
+
+
+# ---------------------------------------------------------------------------
+# Tests: singleton isolation between two independent nodes
+# ---------------------------------------------------------------------------
+
+
+class TestLLMSingletonIsolation(unittest.TestCase):
+    """Two independently constructed node instances do not share LLM state."""
+
+    def test_different_llm_instances_no_shared_state(self):
+        """Injecting different LLMs into two nodes keeps them fully independent."""
+        fake_en = _fake_llm(["English"])
+        fake_es = _fake_llm(["Español"])
+
+        node_en = TranslatorEngNode(_translator_en_state(), {}, llm=fake_en)
+        node_es = TranslatorEngNode(_translator_en_state(), {}, llm=fake_es)
+
+        self.assertIsNot(node_en.llm, node_es.llm)
+        self.assertIs(node_en.get_llm(), fake_en)
+        self.assertIs(node_es.get_llm(), fake_es)
+
+    def test_eng_and_usr_nodes_independent(self):
+        """TranslatorEngNode and TranslatorUsrNode hold separate LLM instances."""
+        fake_eng = _fake_llm(["eng"])
+        fake_usr = _fake_llm(["usr"])
+
+        eng_node = TranslatorEngNode(_translator_en_state(), {}, llm=fake_eng)
+        usr_node = TranslatorUsrNode(_translator_usr_state(), {}, llm=fake_usr)
+
+        self.assertIsNot(eng_node.llm, usr_node.llm)
+        self.assertIs(eng_node.get_llm(), fake_eng)
+        self.assertIs(usr_node.get_llm(), fake_usr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- LLMNode.__init__ accepts llm=None; stores self.llm = llm if llm is not None else default_llm()
- LLMNode.get_llm() returns self.llm directly; no factory call after construction
- TranslatorEngNode, TranslatorUsrNode, TextAnalyzerNode, SummaryExtractorNode, SentimentExtractorNode updated to accept and forward llm=None via super().__init__
- build_graph() in TranslatorEnSubgraf, TranslatorUsrSubgraf, MessageTranslatorSubgraf and TextAnalysisWorkflow made single injection site; default_llm() called once at top, passed via llm= to every node
- CheckTitleRelevance(title, topic, llm=None) accepts optional llm; falls back to default_llm()
- Add tests/test_llm_node_injection.py: 13 tests using FakeListChatModel — no API key, no network call
- Bump version 0.3.3 → 0.3.4