### PR TITLE
feat(circuit-breaker): add sync/async circuit breakers for LLM API pr…

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.3.5] - 2026-04-06
+
+### Feature: async circuit breaker to protect LLM API calls
+
+- Added `src/black_langcube/llm_modules/circuit_breaker.py` — synchronous circuit breaker using `threading.Lock` with a three-state machine (`CLOSED`, `OPEN`, `HALF_OPEN`), module-level singleton registry (`get_circuit_breaker()`, `reset_all_circuit_breakers()`), and custom `CircuitBreakerOpenError` exception
+- Added `src/black_langcube/llm_modules/circuit_breaker_async.py` — asynchronous mirror of the above using `asyncio.Lock`; identical public API so callers only choose the right module for their execution context
+- Both modules read `CB_FAILURE_THRESHOLD` (default `5`) and `CB_RECOVERY_TIMEOUT` (default `60`) from environment variables at import time; no magic values in code
+- `openai.RateLimitError` is intentionally excluded from the failure counter (transient client-side throttling, not evidence the service is down); only `openai.APIConnectionError`, `openai.APITimeoutError`, and `openai.InternalServerError` increment the counter and can open the circuit
+- Updated `robust_invoke_async` to wrap chain invocations in the async circuit breaker; `CircuitBreakerOpenError` returns `{"error": "Circuit breaker open: openai_api"}` immediately without invoking the chain or retrying
+- Updated `robust_invoke` (sync) similarly using `circuit_breaker.py`
+- Exported `get_circuit_breaker`, `reset_all_circuit_breakers`, `CircuitBreakerOpenError`, and their async counterparts from `llm_modules/__init__.py` so library consumers can call `reset_all_circuit_breakers()` in their own test suites
+- Added `tests/test_circuit_breaker.py` covering: all three-state transitions (sync and async), rate-limit exclusion, service-error recording, `get_circuit_breaker()` singleton behaviour, `reset_all_circuit_breakers()` isolation, and `robust_invoke_async` short-circuit behaviour (chain is mocked — no API calls)
+- All tests pass
+
 ## [0.3.4] - 2026-04-06
 
 ### Feature: constructor-level LLM dependency injection

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "black_langcube"
-version = "0.3.4"
+version = "0.3.5"
 description = "A LangGraph-based extension framework for complex workflow applications, enabling the integration of various AI models and tools into a cohesive system."
 readme = "README.md"
 license = "MIT"

--- a/src/black_langcube/__init__.py
+++ b/src/black_langcube/__init__.py
@@ -2,7 +2,7 @@
 Black LangCube - A framework for building LLM applications with LangGraph.
 """
 
-__version__ = "0.3.4"
+__version__ = "0.3.5"
 __description__ = "A framework for building LLM applications with LangGraph"
 
 # Import core components to make them available from the main package

--- a/src/black_langcube/llm_modules/__init__.py
+++ b/src/black_langcube/llm_modules/__init__.py
@@ -1,0 +1,19 @@
+from black_langcube.llm_modules.circuit_breaker import (
+    get_circuit_breaker,
+    reset_all_circuit_breakers,
+    CircuitBreakerOpenError,
+)
+from black_langcube.llm_modules.circuit_breaker_async import (
+    get_circuit_breaker as get_async_circuit_breaker,
+    reset_all_circuit_breakers as reset_all_async_circuit_breakers,
+    CircuitBreakerOpenError as AsyncCircuitBreakerOpenError,
+)
+
+__all__ = [
+    "get_circuit_breaker",
+    "reset_all_circuit_breakers",
+    "CircuitBreakerOpenError",
+    "get_async_circuit_breaker",
+    "reset_all_async_circuit_breakers",
+    "AsyncCircuitBreakerOpenError",
+]

--- a/src/black_langcube/llm_modules/circuit_breaker.py
+++ b/src/black_langcube/llm_modules/circuit_breaker.py
@@ -1,0 +1,171 @@
+"""
+Synchronous circuit breaker for protecting LLM API calls.
+
+Implements a three-state machine (CLOSED → OPEN → HALF_OPEN → CLOSED) using
+a threading.Lock for thread-safe state transitions.
+
+Configuration is read at import time from environment variables:
+  CB_FAILURE_THRESHOLD  — consecutive failures before opening (default: 5)
+  CB_RECOVERY_TIMEOUT   — seconds to wait before probing in HALF_OPEN (default: 60)
+"""
+
+import os
+import threading
+import time
+from enum import Enum
+
+import openai
+
+CIRCUIT_BREAKER_CONFIG = {
+    "openai_api": {
+        "failure_threshold": int(os.getenv("CB_FAILURE_THRESHOLD", "5")),
+        "recovery_timeout": int(os.getenv("CB_RECOVERY_TIMEOUT", "60")),
+    }
+}
+
+SERVICE_ERRORS = (
+    openai.APIConnectionError,
+    openai.APITimeoutError,
+    openai.InternalServerError,
+)
+
+
+class CircuitBreakerOpenError(Exception):
+    """Raised when a call is attempted while the circuit is OPEN."""
+
+
+class CircuitState(Enum):
+    CLOSED = "CLOSED"
+    OPEN = "OPEN"
+    HALF_OPEN = "HALF_OPEN"
+
+
+class CircuitBreaker:
+    def __init__(self, failure_threshold: int, recovery_timeout: int) -> None:
+        self._failure_threshold = failure_threshold
+        self._recovery_timeout = recovery_timeout
+        self._failure_count = 0
+        self._state = CircuitState.CLOSED
+        self._opened_at: float | None = None
+        self._probe_in_flight: bool = False
+        self._lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    # Public state interrogation
+    # ------------------------------------------------------------------
+
+    @property
+    def state(self) -> CircuitState:
+        return self._state
+
+    # ------------------------------------------------------------------
+    # Internal transition helpers
+    # ------------------------------------------------------------------
+
+    def _transition(self, new_state: CircuitState) -> None:
+        self._state = new_state
+        if new_state == CircuitState.OPEN:
+            self._opened_at = time.time()
+
+    def _check_recovery(self) -> None:
+        """Transition OPEN → HALF_OPEN when the timeout has elapsed."""
+        if (
+            self._state == CircuitState.OPEN
+            and self._opened_at is not None
+            and (time.time() - self._opened_at) >= self._recovery_timeout
+        ):
+            self._transition(CircuitState.HALF_OPEN)
+
+    # ------------------------------------------------------------------
+    # Failure / success recording
+    # ------------------------------------------------------------------
+
+    def record_failure(self) -> None:
+        with self._lock:
+            if self._state == CircuitState.HALF_OPEN:
+                self._failure_count = self._failure_threshold
+                self._probe_in_flight = False
+                self._transition(CircuitState.OPEN)
+            elif self._state == CircuitState.CLOSED:
+                self._failure_count += 1
+                if self._failure_count >= self._failure_threshold:
+                    self._transition(CircuitState.OPEN)
+
+    def record_success(self) -> None:
+        with self._lock:
+            self._failure_count = 0
+            self._probe_in_flight = False
+            self._transition(CircuitState.CLOSED)
+
+    # ------------------------------------------------------------------
+    # Call gate
+    # ------------------------------------------------------------------
+
+    def call(self):
+        """
+        Context manager that gates a single synchronous call through the breaker.
+
+        Usage::
+
+            with circuit_breaker.call():
+                result = chain.invoke(...)
+        """
+        return _SyncBreakerContext(self)
+
+
+class _SyncBreakerContext:
+    def __init__(self, breaker: CircuitBreaker) -> None:
+        self._breaker = breaker
+        self._is_probe = False
+
+    def __enter__(self):
+        with self._breaker._lock:
+            self._breaker._check_recovery()
+            if self._breaker._state == CircuitState.OPEN:
+                raise CircuitBreakerOpenError(
+                    "Circuit breaker is OPEN (service unavailable)"
+                )
+            if self._breaker._state == CircuitState.HALF_OPEN:
+                if self._breaker._probe_in_flight:
+                    raise CircuitBreakerOpenError(
+                        "Circuit breaker is HALF_OPEN (probe already in flight)"
+                    )
+                self._breaker._probe_in_flight = True
+                self._is_probe = True
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if exc_type is None:
+            self._breaker.record_success()
+        elif issubclass(exc_type, SERVICE_ERRORS):
+            self._breaker.record_failure()
+        elif self._is_probe:
+            # Other error (e.g. RateLimitError) during a HALF_OPEN probe:
+            # clear the probe flag so future probes are not blocked.
+            with self._breaker._lock:
+                self._breaker._probe_in_flight = False
+        # RateLimitError and other errors are not recorded — let them propagate
+        return False  # never suppress the exception
+
+
+# ------------------------------------------------------------------
+# Module-level registry
+# ------------------------------------------------------------------
+
+_circuit_breaker_registry: dict[str, CircuitBreaker] = {}
+
+
+def get_circuit_breaker(service_name: str) -> CircuitBreaker:
+    """Return the singleton CircuitBreaker for the given service name, creating it if absent."""
+    if service_name not in _circuit_breaker_registry:
+        config = (
+            CIRCUIT_BREAKER_CONFIG.get(service_name)
+            or CIRCUIT_BREAKER_CONFIG["openai_api"]
+        )
+        _circuit_breaker_registry[service_name] = CircuitBreaker(**config)
+    return _circuit_breaker_registry[service_name]
+
+
+def reset_all_circuit_breakers() -> None:
+    """Clear all registered circuit breakers — for use in tests only."""
+    _circuit_breaker_registry.clear()

--- a/src/black_langcube/llm_modules/circuit_breaker_async.py
+++ b/src/black_langcube/llm_modules/circuit_breaker_async.py
@@ -1,0 +1,181 @@
+"""
+Asynchronous circuit breaker for protecting LLM API calls.
+
+Implements a three-state machine (CLOSED → OPEN → HALF_OPEN → CLOSED) using
+an asyncio.Lock for async-safe state transitions.
+
+Configuration is read at import time from environment variables:
+  CB_FAILURE_THRESHOLD  — consecutive failures before opening (default: 5)
+  CB_RECOVERY_TIMEOUT   — seconds to wait before probing in HALF_OPEN (default: 60)
+
+This module mirrors the public API of circuit_breaker.py exactly, differing only
+in the locking primitive and async context-manager usage.
+"""
+
+import asyncio
+import os
+import time
+from enum import Enum
+
+import openai
+
+CIRCUIT_BREAKER_CONFIG = {
+    "openai_api": {
+        "failure_threshold": int(os.getenv("CB_FAILURE_THRESHOLD", "5")),
+        "recovery_timeout": int(os.getenv("CB_RECOVERY_TIMEOUT", "60")),
+    }
+}
+
+SERVICE_ERRORS = (
+    openai.APIConnectionError,
+    openai.APITimeoutError,
+    openai.InternalServerError,
+)
+
+
+class CircuitBreakerOpenError(Exception):
+    """Raised when a call is attempted while the circuit is OPEN."""
+
+
+class CircuitState(Enum):
+    CLOSED = "CLOSED"
+    OPEN = "OPEN"
+    HALF_OPEN = "HALF_OPEN"
+
+
+class CircuitBreakerAsync:
+    def __init__(self, failure_threshold: int, recovery_timeout: int) -> None:
+        self._failure_threshold = failure_threshold
+        self._recovery_timeout = recovery_timeout
+        self._failure_count = 0
+        self._state = CircuitState.CLOSED
+        self._opened_at: float | None = None
+        self._probe_in_flight: bool = False
+        # asyncio.Lock is created lazily to avoid issues with event-loop binding
+        # in tests that spin up fresh loops per test case.
+        self._lock: asyncio.Lock | None = None
+
+    def _get_lock(self) -> asyncio.Lock:
+        if self._lock is None:
+            self._lock = asyncio.Lock()
+        return self._lock
+
+    # ------------------------------------------------------------------
+    # Public state interrogation
+    # ------------------------------------------------------------------
+
+    @property
+    def state(self) -> CircuitState:
+        return self._state
+
+    # ------------------------------------------------------------------
+    # Internal transition helpers
+    # ------------------------------------------------------------------
+
+    def _transition(self, new_state: CircuitState) -> None:
+        self._state = new_state
+        if new_state == CircuitState.OPEN:
+            self._opened_at = time.time()
+
+    def _check_recovery(self) -> None:
+        """Transition OPEN → HALF_OPEN when the timeout has elapsed."""
+        if (
+            self._state == CircuitState.OPEN
+            and self._opened_at is not None
+            and (time.time() - self._opened_at) >= self._recovery_timeout
+        ):
+            self._transition(CircuitState.HALF_OPEN)
+
+    # ------------------------------------------------------------------
+    # Failure / success recording
+    # ------------------------------------------------------------------
+
+    async def record_failure(self) -> None:
+        async with self._get_lock():
+            if self._state == CircuitState.HALF_OPEN:
+                self._failure_count = self._failure_threshold
+                self._probe_in_flight = False
+                self._transition(CircuitState.OPEN)
+            elif self._state == CircuitState.CLOSED:
+                self._failure_count += 1
+                if self._failure_count >= self._failure_threshold:
+                    self._transition(CircuitState.OPEN)
+
+    async def record_success(self) -> None:
+        async with self._get_lock():
+            self._failure_count = 0
+            self._probe_in_flight = False
+            self._transition(CircuitState.CLOSED)
+
+    # ------------------------------------------------------------------
+    # Call gate
+    # ------------------------------------------------------------------
+
+    def call(self):
+        """
+        Async context manager that gates a single call through the breaker.
+
+        Usage::
+
+            async with circuit_breaker.call():
+                result = await chain.ainvoke(...)
+        """
+        return _AsyncBreakerContext(self)
+
+
+class _AsyncBreakerContext:
+    def __init__(self, breaker: CircuitBreakerAsync) -> None:
+        self._breaker = breaker
+        self._is_probe = False
+
+    async def __aenter__(self):
+        async with self._breaker._get_lock():
+            self._breaker._check_recovery()
+            if self._breaker._state == CircuitState.OPEN:
+                raise CircuitBreakerOpenError(
+                    "Circuit breaker is OPEN (service unavailable)"
+                )
+            if self._breaker._state == CircuitState.HALF_OPEN:
+                if self._breaker._probe_in_flight:
+                    raise CircuitBreakerOpenError(
+                        "Circuit breaker is HALF_OPEN (probe already in flight)"
+                    )
+                self._breaker._probe_in_flight = True
+                self._is_probe = True
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        if exc_type is None:
+            await self._breaker.record_success()
+        elif issubclass(exc_type, SERVICE_ERRORS):
+            await self._breaker.record_failure()
+        elif self._is_probe:
+            # Other error (e.g. RateLimitError) during a HALF_OPEN probe:
+            # clear the probe flag so future probes are not blocked.
+            async with self._breaker._get_lock():
+                self._breaker._probe_in_flight = False
+        # RateLimitError and other errors are not recorded — let them propagate
+        return False  # never suppress the exception
+
+
+# ------------------------------------------------------------------
+# Module-level registry
+# ------------------------------------------------------------------
+
+_circuit_breaker_registry: dict[str, CircuitBreakerAsync] = {}
+
+
+def get_circuit_breaker(service_name: str) -> CircuitBreakerAsync:
+    """Return the singleton CircuitBreakerAsync for the given service name, creating it if absent."""
+    if service_name not in _circuit_breaker_registry:
+        config = (
+            CIRCUIT_BREAKER_CONFIG.get(service_name)
+            or CIRCUIT_BREAKER_CONFIG["openai_api"]
+        )
+        _circuit_breaker_registry[service_name] = CircuitBreakerAsync(**config)
+    return _circuit_breaker_registry[service_name]
+
+
+def reset_all_circuit_breakers() -> None:
+    """Clear all registered circuit breakers — for use in tests only."""
+    _circuit_breaker_registry.clear()

--- a/src/black_langcube/llm_modules/robust_invoke.py
+++ b/src/black_langcube/llm_modules/robust_invoke.py
@@ -1,11 +1,19 @@
 import logging
 import time
+
 import openai
-from pydantic import ValidationError
 from langchain_core.exceptions import OutputParserException
 from langchain_community.callbacks import get_openai_callback
+from pydantic import ValidationError
+
+from black_langcube.llm_modules.circuit_breaker import (
+    CircuitBreakerOpenError,
+    get_circuit_breaker,
+)
 
 logger = logging.getLogger(__name__)
+
+_SERVICE_NAME = "openai_api"
 
 
 def robust_invoke(chain, extra_input=None, max_retries=3, backoff_factor=65):
@@ -13,28 +21,36 @@ def robust_invoke(chain, extra_input=None, max_retries=3, backoff_factor=65):
     A robust function to invoke a LangChain chain, handling:
       - OutputParserException
       - ValidationError
-      - openai.error.RateLimitError (with exponential backoff)
-      - openai.error.OpenAIError
+      - openai.RateLimitError (with linear backoff; does not increment the
+        circuit-breaker failure counter)
+      - openai.APIConnectionError / openai.APITimeoutError / openai.InternalServerError
+        (recorded by the circuit breaker; circuit opens after CB_FAILURE_THRESHOLD
+        consecutive such failures)
+      - openai.OpenAIError (other OpenAI errors — not recorded by the circuit breaker)
+      - CircuitBreakerOpenError (circuit is OPEN; returns error dict immediately without
+        invoking the chain)
     and returning the required output or a dictionary with 'error' key.
 
     :param chain: A LangChain pipeline, e.g. prompt | llm | parser
-    :param input_data: Dictionary of inputs to pass to chain.invoke()
+    :param extra_input: Dictionary of inputs to pass to chain.invoke()
     :param max_retries: Maximum attempts to retry on rate-limit errors
     :param backoff_factor: Simple linear backoff (sleep time is backoff_factor * attempt)
     :return: result on success or {'error': ...} on failure
     """
 
-    # Initialize empty tokens dict for error cases
     empty_tokens = {
         "tokens_in": 0,
         "tokens_out": 0,
         "tokens_price": 0,
     }
 
+    circuit_breaker = get_circuit_breaker(_SERVICE_NAME)
+
     for attempt in range(max_retries):
         try:
-            with get_openai_callback() as cb:
-                result = chain.invoke(extra_input)
+            with circuit_breaker.call():
+                with get_openai_callback() as cb:
+                    result = chain.invoke(extra_input)
 
             tokens = {
                 "tokens_in": cb.prompt_tokens,
@@ -44,12 +60,14 @@ def robust_invoke(chain, extra_input=None, max_retries=3, backoff_factor=65):
 
             return result, tokens
 
+        except CircuitBreakerOpenError:
+            return {"error": f"Circuit breaker open: {_SERVICE_NAME}"}, empty_tokens
+
         except (OutputParserException, ValidationError) as e:
-            # Return parser/validation errors directly
             return {"error": str(e)}, empty_tokens
 
         except openai.RateLimitError as e:
-            # Handle rate-limit by retrying with exponential backoff
+            # Rate-limit errors are transient — do NOT record a circuit failure.
             logger.warning(f"Rate limit error: {e}")
             if attempt < max_retries - 1:
                 sleep_time = backoff_factor * attempt
@@ -60,11 +78,18 @@ def robust_invoke(chain, extra_input=None, max_retries=3, backoff_factor=65):
                     "error": f"Rate limit error after {max_retries} attempts: {str(e)}"
                 }, empty_tokens
 
-        except openai.OpenAIError as e:
-            # Any other OpenAI-specific error
+        except (
+            openai.APIConnectionError,
+            openai.APITimeoutError,
+            openai.InternalServerError,
+        ) as e:
+            # These errors indicate a structural service failure — the circuit breaker
+            # context manager already recorded the failure in __exit__; return immediately.
             return {"error": f"OpenAI error: {str(e)}"}, empty_tokens
 
-    # If we exit the loop for any reason (unlikely without returning), handle gracefully
+        except openai.OpenAIError as e:
+            return {"error": f"OpenAI error: {str(e)}"}, empty_tokens
+
     return {
         "error": "Unknown error or maximum retries reached without success."
     }, empty_tokens

--- a/src/black_langcube/llm_modules/robust_invoke_async.py
+++ b/src/black_langcube/llm_modules/robust_invoke_async.py
@@ -5,6 +5,7 @@ This module provides async-safe invocation of LangChain chains with:
 - Exponential backoff for rate limiting
 - OpenAI API error handling
 - Async sleep for non-blocking delays
+- Async circuit breaker to stop cascading failures on a fully unavailable API
 """
 
 import asyncio
@@ -15,7 +16,14 @@ from langchain_core.exceptions import OutputParserException
 from langchain_community.callbacks import get_openai_callback
 from pydantic import ValidationError
 
+from black_langcube.llm_modules.circuit_breaker_async import (
+    CircuitBreakerOpenError,
+    get_circuit_breaker,
+)
+
 logger = logging.getLogger(__name__)
+
+_SERVICE_NAME = "openai_api"
 
 
 async def robust_invoke_async(
@@ -27,8 +35,14 @@ async def robust_invoke_async(
     Handles:
       - OutputParserException
       - ValidationError
-      - openai.RateLimitError (with exponential backoff using asyncio.sleep)
-      - openai.OpenAIError
+      - openai.RateLimitError (with linear backoff using asyncio.sleep; does not
+        increment the circuit-breaker failure counter)
+      - openai.APIConnectionError / openai.APITimeoutError / openai.InternalServerError
+        (recorded by the circuit breaker; circuit opens after CB_FAILURE_THRESHOLD
+        consecutive such failures)
+      - openai.OpenAIError (other OpenAI errors — not recorded by the circuit breaker)
+      - CircuitBreakerOpenError (circuit is OPEN; returns error dict immediately without
+        invoking the chain)
 
     Args:
         chain: A LangChain pipeline, e.g. prompt | llm | parser
@@ -46,17 +60,20 @@ async def robust_invoke_async(
         "tokens_price": 0,
     }
 
+    circuit_breaker = get_circuit_breaker(_SERVICE_NAME)
+
     for attempt in range(max_retries):
         try:
-            with get_openai_callback() as cb:
-                if hasattr(chain, "ainvoke"):
-                    result = await chain.ainvoke(extra_input)
-                else:
-                    # Fallback to sync invoke in thread pool
-                    loop = asyncio.get_event_loop()
-                    result = await loop.run_in_executor(
-                        None, lambda: chain.invoke(extra_input)
-                    )
+            async with circuit_breaker.call():
+                with get_openai_callback() as cb:
+                    if hasattr(chain, "ainvoke"):
+                        result = await chain.ainvoke(extra_input)
+                    else:
+                        # Fallback to sync invoke in thread pool
+                        loop = asyncio.get_event_loop()
+                        result = await loop.run_in_executor(
+                            None, lambda: chain.invoke(extra_input)
+                        )
 
             tokens = {
                 "tokens_in": cb.prompt_tokens,
@@ -65,10 +82,14 @@ async def robust_invoke_async(
             }
             return result, tokens
 
+        except CircuitBreakerOpenError:
+            return {"error": f"Circuit breaker open: {_SERVICE_NAME}"}, empty_tokens
+
         except (OutputParserException, ValidationError) as e:
             return {"error": str(e)}, empty_tokens
 
         except openai.RateLimitError as e:
+            # Rate-limit errors are transient — do NOT record a circuit failure.
             logger.warning(f"Rate limit error: {e}")
             if attempt < max_retries - 1:
                 sleep_time = backoff_factor * attempt
@@ -78,6 +99,15 @@ async def robust_invoke_async(
                 return {
                     "error": f"Rate limit error after {max_retries} attempts: {str(e)}"
                 }, empty_tokens
+
+        except (
+            openai.APIConnectionError,
+            openai.APITimeoutError,
+            openai.InternalServerError,
+        ) as e:
+            # These errors indicate a structural service failure — the circuit breaker
+            # context manager already recorded the failure in __aexit__; return immediately.
+            return {"error": f"OpenAI error: {str(e)}"}, empty_tokens
 
         except openai.OpenAIError as e:
             return {"error": f"OpenAI error: {str(e)}"}, empty_tokens

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,22 @@
+"""
+pytest configuration: autouse fixture that resets all circuit breakers before and
+after every test so state cannot bleed between test cases.
+"""
+
+import pytest
+
+from black_langcube.llm_modules.circuit_breaker import (
+    reset_all_circuit_breakers as reset_sync,
+)
+from black_langcube.llm_modules.circuit_breaker_async import (
+    reset_all_circuit_breakers as reset_async,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_circuit_breakers():
+    reset_sync()
+    reset_async()
+    yield
+    reset_sync()
+    reset_async()

--- a/tests/test_circuit_breaker.py
+++ b/tests/test_circuit_breaker.py
@@ -1,0 +1,636 @@
+"""
+Unit tests for the sync and async circuit-breaker implementations,
+robust_invoke_async short-circuit behavior, and the module-level registry.
+
+All tests run without real API calls — the LangChain chain and openai errors are mocked.
+"""
+
+import asyncio
+import sys
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root / "src"))
+
+import openai  # noqa: E402
+
+from black_langcube.llm_modules.circuit_breaker import (  # noqa: E402
+    CircuitBreaker,
+    CircuitBreakerOpenError,
+    CircuitState,
+    get_circuit_breaker,
+    reset_all_circuit_breakers,
+)
+from black_langcube.llm_modules.circuit_breaker_async import (  # noqa: E402
+    CircuitBreakerAsync,
+    CircuitBreakerOpenError as AsyncCircuitBreakerOpenError,
+    CircuitState as AsyncCircuitState,
+    get_circuit_breaker as async_get_circuit_breaker,
+    reset_all_circuit_breakers as async_reset_all_circuit_breakers,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_sync_breaker(threshold=3, timeout=60) -> CircuitBreaker:
+    return CircuitBreaker(failure_threshold=threshold, recovery_timeout=timeout)
+
+
+def _make_async_breaker(threshold=3, timeout=60) -> CircuitBreakerAsync:
+    return CircuitBreakerAsync(failure_threshold=threshold, recovery_timeout=timeout)
+
+
+def _connection_error() -> openai.APIConnectionError:
+    req = MagicMock()
+    return openai.APIConnectionError(request=req)
+
+
+def _timeout_error() -> openai.APITimeoutError:
+    req = MagicMock()
+    return openai.APITimeoutError(request=req)
+
+
+def _internal_error() -> openai.InternalServerError:
+    resp = MagicMock()
+    resp.headers = {}
+    return openai.InternalServerError(message="internal", response=resp, body=None)
+
+
+def _rate_limit_error() -> openai.RateLimitError:
+    resp = MagicMock()
+    resp.headers = {}
+    return openai.RateLimitError(message="rate limit", response=resp, body=None)
+
+
+# ---------------------------------------------------------------------------
+# Sync circuit-breaker tests
+# ---------------------------------------------------------------------------
+
+
+class TestSyncCircuitBreakerTransitions(unittest.TestCase):
+    def setUp(self):
+        reset_all_circuit_breakers()
+
+    def tearDown(self):
+        reset_all_circuit_breakers()
+
+    def test_initial_state_is_closed(self):
+        cb = _make_sync_breaker()
+        self.assertEqual(cb.state, CircuitState.CLOSED)
+
+    def test_closed_to_open_after_threshold_failures(self):
+        cb = _make_sync_breaker(threshold=3)
+        cb.record_failure()
+        cb.record_failure()
+        self.assertEqual(cb.state, CircuitState.CLOSED)
+        cb.record_failure()  # 3rd — should open
+        self.assertEqual(cb.state, CircuitState.OPEN)
+
+    def test_open_rejects_call(self):
+        cb = _make_sync_breaker(threshold=1)
+        cb.record_failure()
+        self.assertEqual(cb.state, CircuitState.OPEN)
+        with self.assertRaises(CircuitBreakerOpenError):
+            with cb.call():
+                pass  # pragma: no cover
+
+    def test_open_transitions_to_half_open_after_timeout(self):
+        cb = _make_sync_breaker(threshold=1, timeout=10)
+        cb.record_failure()
+        self.assertEqual(cb.state, CircuitState.OPEN)
+        # Before timeout: probe calls are still rejected
+        with self.assertRaises(CircuitBreakerOpenError):
+            with cb.call():
+                pass  # pragma: no cover
+        # After timeout elapses: _check_recovery transitions to HALF_OPEN
+        cb._opened_at = time.time() - 11
+        cb._check_recovery()
+        self.assertEqual(cb.state, CircuitState.HALF_OPEN)
+
+    def test_half_open_to_closed_on_success(self):
+        cb = _make_sync_breaker(threshold=1)
+        cb.record_failure()
+        cb._opened_at = time.time() - 70  # force past recovery_timeout
+        cb._check_recovery()
+        self.assertEqual(cb.state, CircuitState.HALF_OPEN)
+        cb.record_success()
+        self.assertEqual(cb.state, CircuitState.CLOSED)
+
+    def test_half_open_to_open_on_failure(self):
+        cb = _make_sync_breaker(threshold=1)
+        cb.record_failure()
+        cb._opened_at = time.time() - 70
+        cb._check_recovery()
+        self.assertEqual(cb.state, CircuitState.HALF_OPEN)
+        cb.record_failure()
+        self.assertEqual(cb.state, CircuitState.OPEN)
+
+    def test_rate_limit_error_does_not_increment_counter(self):
+        cb = _make_sync_breaker(threshold=3)
+        # RateLimitError is NOT a SERVICE_ERROR — context manager won't record it
+        for _ in range(5):
+            try:
+                with cb.call():
+                    raise _rate_limit_error()
+            except openai.RateLimitError:
+                pass
+        self.assertEqual(cb._failure_count, 0)
+        self.assertEqual(cb.state, CircuitState.CLOSED)
+
+    def test_service_errors_increment_counter(self):
+        for make_error in [_connection_error, _timeout_error, _internal_error]:
+            with self.subTest(error=make_error):
+                cb = _make_sync_breaker(threshold=5)
+                try:
+                    with cb.call():
+                        raise make_error()
+                except Exception:
+                    pass
+                self.assertEqual(cb._failure_count, 1)
+
+    def test_success_resets_failure_count(self):
+        cb = _make_sync_breaker(threshold=5)
+        cb.record_failure()
+        cb.record_failure()
+        self.assertEqual(cb._failure_count, 2)
+        cb.record_success()
+        self.assertEqual(cb._failure_count, 0)
+        self.assertEqual(cb.state, CircuitState.CLOSED)
+
+    def test_half_open_second_probe_is_blocked(self):
+        import threading
+
+        cb = _make_sync_breaker(threshold=1)
+        cb.record_failure()
+        cb._opened_at = time.time() - 70
+        cb._check_recovery()
+        self.assertEqual(cb.state, CircuitState.HALF_OPEN)
+
+        probe_entered = threading.Event()
+        probe_continue = threading.Event()
+        second_was_blocked = threading.Event()
+
+        def first_probe():
+            with cb.call():
+                probe_entered.set()
+                probe_continue.wait(timeout=2)
+
+        def second_probe():
+            probe_entered.wait(timeout=2)
+            try:
+                with cb.call():
+                    pass  # pragma: no cover
+            except CircuitBreakerOpenError:
+                second_was_blocked.set()
+            finally:
+                probe_continue.set()  # unblock first probe
+
+        t1 = threading.Thread(target=first_probe)
+        t2 = threading.Thread(target=second_probe)
+        t1.start()
+        t2.start()
+        t1.join(timeout=3)
+        t2.join(timeout=3)
+
+        self.assertTrue(
+            second_was_blocked.is_set(),
+            "Second concurrent probe should be blocked in HALF_OPEN",
+        )
+
+    def test_half_open_probe_flag_cleared_after_success(self):
+        cb = _make_sync_breaker(threshold=1)
+        cb.record_failure()
+        cb._opened_at = time.time() - 70
+        cb._check_recovery()
+        with cb.call():  # probe succeeds
+            pass
+        self.assertEqual(cb.state, CircuitState.CLOSED)
+        self.assertFalse(cb._probe_in_flight)
+
+    def test_half_open_probe_flag_cleared_after_service_failure(self):
+        cb = _make_sync_breaker(threshold=1)
+        cb.record_failure()
+        cb._opened_at = time.time() - 70
+        cb._check_recovery()
+        try:
+            with cb.call():
+                raise _connection_error()
+        except openai.APIConnectionError:
+            pass
+        self.assertEqual(cb.state, CircuitState.OPEN)
+        self.assertFalse(cb._probe_in_flight)
+
+    def test_half_open_probe_flag_cleared_after_non_service_error(self):
+        cb = _make_sync_breaker(threshold=1)
+        cb.record_failure()
+        cb._opened_at = time.time() - 70
+        cb._check_recovery()
+        try:
+            with cb.call():
+                raise _rate_limit_error()
+        except openai.RateLimitError:
+            pass
+        # State stays HALF_OPEN (rate limit is not a service error)
+        self.assertEqual(cb.state, CircuitState.HALF_OPEN)
+        # But probe flag must be cleared so a future probe can attempt
+        self.assertFalse(cb._probe_in_flight)
+
+
+# ---------------------------------------------------------------------------
+# Sync registry tests
+# ---------------------------------------------------------------------------
+
+
+class TestSyncRegistry(unittest.TestCase):
+    def setUp(self):
+        reset_all_circuit_breakers()
+
+    def tearDown(self):
+        reset_all_circuit_breakers()
+
+    def test_get_circuit_breaker_returns_same_instance(self):
+        a = get_circuit_breaker("openai_api")
+        b = get_circuit_breaker("openai_api")
+        self.assertIs(a, b)
+
+    def test_reset_all_circuit_breakers_clears_registry(self):
+        a = get_circuit_breaker("openai_api")
+        reset_all_circuit_breakers()
+        b = get_circuit_breaker("openai_api")
+        self.assertIsNot(a, b)
+
+    def test_unknown_service_gets_default_config(self):
+        cb = get_circuit_breaker("some_unknown_service")
+        self.assertIsInstance(cb, CircuitBreaker)
+
+
+# ---------------------------------------------------------------------------
+# Async circuit-breaker tests
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncCircuitBreakerTransitions(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        async_reset_all_circuit_breakers()
+
+    def tearDown(self):
+        async_reset_all_circuit_breakers()
+
+    async def test_initial_state_is_closed(self):
+        cb = _make_async_breaker()
+        self.assertEqual(cb.state, AsyncCircuitState.CLOSED)
+
+    async def test_closed_to_open_after_threshold_failures(self):
+        cb = _make_async_breaker(threshold=3)
+        await cb.record_failure()
+        await cb.record_failure()
+        self.assertEqual(cb.state, AsyncCircuitState.CLOSED)
+        await cb.record_failure()
+        self.assertEqual(cb.state, AsyncCircuitState.OPEN)
+
+    async def test_open_rejects_call(self):
+        cb = _make_async_breaker(threshold=1)
+        await cb.record_failure()
+        self.assertEqual(cb.state, AsyncCircuitState.OPEN)
+        with self.assertRaises(AsyncCircuitBreakerOpenError):
+            async with cb.call():
+                pass  # pragma: no cover
+
+    async def test_open_transitions_to_half_open_after_timeout(self):
+        cb = _make_async_breaker(threshold=1, timeout=10)
+        await cb.record_failure()
+        self.assertEqual(cb.state, AsyncCircuitState.OPEN)
+        cb._opened_at = time.time() - 11
+        cb._check_recovery()
+        self.assertEqual(cb.state, AsyncCircuitState.HALF_OPEN)
+
+    async def test_half_open_to_closed_on_success(self):
+        cb = _make_async_breaker(threshold=1)
+        await cb.record_failure()
+        cb._opened_at = time.time() - 70
+        cb._check_recovery()
+        self.assertEqual(cb.state, AsyncCircuitState.HALF_OPEN)
+        await cb.record_success()
+        self.assertEqual(cb.state, AsyncCircuitState.CLOSED)
+
+    async def test_half_open_to_open_on_failure(self):
+        cb = _make_async_breaker(threshold=1)
+        await cb.record_failure()
+        cb._opened_at = time.time() - 70
+        cb._check_recovery()
+        self.assertEqual(cb.state, AsyncCircuitState.HALF_OPEN)
+        await cb.record_failure()
+        self.assertEqual(cb.state, AsyncCircuitState.OPEN)
+
+    async def test_rate_limit_error_does_not_increment_counter(self):
+        cb = _make_async_breaker(threshold=3)
+        for _ in range(5):
+            try:
+                async with cb.call():
+                    raise _rate_limit_error()
+            except openai.RateLimitError:
+                pass
+        self.assertEqual(cb._failure_count, 0)
+        self.assertEqual(cb.state, AsyncCircuitState.CLOSED)
+
+    async def test_service_errors_increment_counter(self):
+        for make_error in [_connection_error, _timeout_error, _internal_error]:
+            with self.subTest(error=make_error):
+                cb = _make_async_breaker(threshold=5)
+                try:
+                    async with cb.call():
+                        raise make_error()
+                except Exception:
+                    pass
+                self.assertEqual(cb._failure_count, 1)
+                # reset for next subTest
+                cb._failure_count = 0
+
+    async def test_success_resets_failure_count(self):
+        cb = _make_async_breaker(threshold=5)
+        await cb.record_failure()
+        await cb.record_failure()
+        self.assertEqual(cb._failure_count, 2)
+        await cb.record_success()
+        self.assertEqual(cb._failure_count, 0)
+        self.assertEqual(cb.state, AsyncCircuitState.CLOSED)
+
+    async def test_half_open_second_probe_is_blocked(self):
+        cb = _make_async_breaker(threshold=1)
+        await cb.record_failure()
+        cb._opened_at = time.time() - 70
+        cb._check_recovery()
+        self.assertEqual(cb.state, AsyncCircuitState.HALF_OPEN)
+
+        probe_entered = asyncio.Event()
+        probe_continue = asyncio.Event()
+        second_was_blocked = False
+
+        async def first_probe():
+            async with cb.call():
+                probe_entered.set()
+                await probe_continue.wait()
+
+        async def second_probe():
+            nonlocal second_was_blocked
+            await probe_entered.wait()
+            try:
+                async with cb.call():
+                    pass  # pragma: no cover
+            except AsyncCircuitBreakerOpenError:
+                second_was_blocked = True
+            finally:
+                probe_continue.set()  # unblock first probe
+
+        await asyncio.gather(first_probe(), second_probe())
+        self.assertTrue(
+            second_was_blocked, "Second concurrent probe should be blocked in HALF_OPEN"
+        )
+
+    async def test_half_open_probe_flag_cleared_after_success(self):
+        cb = _make_async_breaker(threshold=1)
+        await cb.record_failure()
+        cb._opened_at = time.time() - 70
+        cb._check_recovery()
+        async with cb.call():  # probe succeeds
+            pass
+        self.assertEqual(cb.state, AsyncCircuitState.CLOSED)
+        self.assertFalse(cb._probe_in_flight)
+
+    async def test_half_open_probe_flag_cleared_after_service_failure(self):
+        cb = _make_async_breaker(threshold=1)
+        await cb.record_failure()
+        cb._opened_at = time.time() - 70
+        cb._check_recovery()
+        try:
+            async with cb.call():
+                raise _connection_error()
+        except openai.APIConnectionError:
+            pass
+        self.assertEqual(cb.state, AsyncCircuitState.OPEN)
+        self.assertFalse(cb._probe_in_flight)
+
+    async def test_half_open_probe_flag_cleared_after_non_service_error(self):
+        cb = _make_async_breaker(threshold=1)
+        await cb.record_failure()
+        cb._opened_at = time.time() - 70
+        cb._check_recovery()
+        try:
+            async with cb.call():
+                raise _rate_limit_error()
+        except openai.RateLimitError:
+            pass
+        # State stays HALF_OPEN (rate limit is not a service error)
+        self.assertEqual(cb.state, AsyncCircuitState.HALF_OPEN)
+        # But probe flag must be cleared so a future probe can attempt
+        self.assertFalse(cb._probe_in_flight)
+
+
+# ---------------------------------------------------------------------------
+# Async registry tests
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncRegistry(unittest.TestCase):
+    def setUp(self):
+        async_reset_all_circuit_breakers()
+
+    def tearDown(self):
+        async_reset_all_circuit_breakers()
+
+    def test_get_circuit_breaker_returns_same_instance(self):
+        a = async_get_circuit_breaker("openai_api")
+        b = async_get_circuit_breaker("openai_api")
+        self.assertIs(a, b)
+
+    def test_reset_all_circuit_breakers_clears_registry(self):
+        a = async_get_circuit_breaker("openai_api")
+        async_reset_all_circuit_breakers()
+        b = async_get_circuit_breaker("openai_api")
+        self.assertIsNot(a, b)
+
+    def test_unknown_service_gets_default_config(self):
+        cb = async_get_circuit_breaker("some_unknown_service")
+        self.assertIsInstance(cb, CircuitBreakerAsync)
+
+
+# ---------------------------------------------------------------------------
+# robust_invoke_async integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestRobustInvokeAsyncCircuitBreaker(unittest.IsolatedAsyncioTestCase):
+    """
+    Verifies robust_invoke_async short-circuits without calling the chain when
+    the circuit is OPEN and correctly records/ignores failures by error type.
+    """
+
+    def setUp(self):
+        async_reset_all_circuit_breakers()
+
+    def tearDown(self):
+        async_reset_all_circuit_breakers()
+
+    async def _invoke(self, chain, **kwargs):
+        from black_langcube.llm_modules.robust_invoke_async import robust_invoke_async
+
+        return await robust_invoke_async(chain, **kwargs)
+
+    def _open_circuit(self):
+        """Force the openai_api circuit into OPEN state."""
+        cb = async_get_circuit_breaker("openai_api")
+        cb._state = AsyncCircuitState.OPEN
+        cb._opened_at = time.time()
+        return cb
+
+    async def test_open_circuit_returns_error_dict_without_calling_chain(self):
+        self._open_circuit()
+        chain = AsyncMock()
+        result, tokens = await self._invoke(chain)
+        self.assertIn("error", result)
+        self.assertIn("Circuit breaker open", result["error"])
+        chain.ainvoke.assert_not_called()
+
+    async def test_rate_limit_error_does_not_open_circuit(self):
+        chain = MagicMock()
+        chain.ainvoke = AsyncMock(side_effect=_rate_limit_error())
+
+        with patch("langchain_community.callbacks.get_openai_callback") as mock_cb_ctx:
+            mock_cb = MagicMock()
+            mock_cb.prompt_tokens = 0
+            mock_cb.completion_tokens = 0
+            mock_cb.total_cost = 0
+            mock_cb_ctx.return_value.__enter__ = MagicMock(return_value=mock_cb)
+            mock_cb_ctx.return_value.__exit__ = MagicMock(return_value=False)
+            result, _ = await self._invoke(chain, max_retries=1)
+
+        cb = async_get_circuit_breaker("openai_api")
+        self.assertEqual(cb._failure_count, 0)
+        self.assertEqual(cb.state, AsyncCircuitState.CLOSED)
+
+    async def test_connection_error_is_recorded_by_circuit_breaker(self):
+        chain = MagicMock()
+        chain.ainvoke = AsyncMock(side_effect=_connection_error())
+
+        with patch("langchain_community.callbacks.get_openai_callback") as mock_cb_ctx:
+            mock_cb = MagicMock()
+            mock_cb_ctx.return_value.__enter__ = MagicMock(return_value=mock_cb)
+            mock_cb_ctx.return_value.__exit__ = MagicMock(return_value=False)
+            result, _ = await self._invoke(chain, max_retries=1)
+
+        cb = async_get_circuit_breaker("openai_api")
+        self.assertEqual(cb._failure_count, 1)
+        self.assertIn("error", result)
+
+    async def test_threshold_failures_open_circuit(self):
+        """After CB_FAILURE_THRESHOLD consecutive service errors the circuit opens."""
+        chain = MagicMock()
+        chain.ainvoke = AsyncMock(side_effect=_connection_error())
+
+        cb = async_get_circuit_breaker("openai_api")
+        threshold = cb._failure_threshold
+
+        with patch("langchain_community.callbacks.get_openai_callback") as mock_cb_ctx:
+            mock_cb = MagicMock()
+            mock_cb_ctx.return_value.__enter__ = MagicMock(return_value=mock_cb)
+            mock_cb_ctx.return_value.__exit__ = MagicMock(return_value=False)
+            for _ in range(threshold):
+                await self._invoke(chain, max_retries=1)
+
+        self.assertEqual(cb.state, AsyncCircuitState.OPEN)
+
+
+# ---------------------------------------------------------------------------
+# robust_invoke (sync) integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestRobustInvokeCircuitBreaker(unittest.TestCase):
+    """
+    Verifies robust_invoke short-circuits without calling the chain when the
+    circuit is OPEN and correctly records/ignores failures by error type.
+    """
+
+    def setUp(self):
+        reset_all_circuit_breakers()
+
+    def tearDown(self):
+        reset_all_circuit_breakers()
+
+    def _invoke(self, chain, **kwargs):
+        from black_langcube.llm_modules.robust_invoke import robust_invoke
+
+        return robust_invoke(chain, **kwargs)
+
+    def _open_circuit(self):
+        """Force the openai_api circuit into OPEN state."""
+        cb = get_circuit_breaker("openai_api")
+        cb._state = CircuitState.OPEN
+        cb._opened_at = time.time()
+        return cb
+
+    def test_open_circuit_returns_error_dict_without_calling_chain(self):
+        self._open_circuit()
+        chain = MagicMock()
+        result, tokens = self._invoke(chain)
+        self.assertIn("error", result)
+        self.assertIn("Circuit breaker open", result["error"])
+        chain.invoke.assert_not_called()
+
+    def test_rate_limit_error_does_not_open_circuit(self):
+        chain = MagicMock()
+        chain.invoke = MagicMock(side_effect=_rate_limit_error())
+
+        with patch("langchain_community.callbacks.get_openai_callback") as mock_cb_ctx:
+            mock_cb = MagicMock()
+            mock_cb.prompt_tokens = 0
+            mock_cb.completion_tokens = 0
+            mock_cb.total_cost = 0
+            mock_cb_ctx.return_value.__enter__ = MagicMock(return_value=mock_cb)
+            mock_cb_ctx.return_value.__exit__ = MagicMock(return_value=False)
+            result, _ = self._invoke(chain, max_retries=1)
+
+        cb = get_circuit_breaker("openai_api")
+        self.assertEqual(cb._failure_count, 0)
+        self.assertEqual(cb.state, CircuitState.CLOSED)
+
+    def test_connection_error_is_recorded_by_circuit_breaker(self):
+        chain = MagicMock()
+        chain.invoke = MagicMock(side_effect=_connection_error())
+
+        with patch("langchain_community.callbacks.get_openai_callback") as mock_cb_ctx:
+            mock_cb = MagicMock()
+            mock_cb_ctx.return_value.__enter__ = MagicMock(return_value=mock_cb)
+            mock_cb_ctx.return_value.__exit__ = MagicMock(return_value=False)
+            result, _ = self._invoke(chain, max_retries=1)
+
+        cb = get_circuit_breaker("openai_api")
+        self.assertEqual(cb._failure_count, 1)
+        self.assertIn("error", result)
+
+    def test_threshold_failures_open_circuit(self):
+        """After CB_FAILURE_THRESHOLD consecutive service errors the circuit opens."""
+        chain = MagicMock()
+        chain.invoke = MagicMock(side_effect=_connection_error())
+
+        cb = get_circuit_breaker("openai_api")
+        threshold = cb._failure_threshold
+
+        with patch("langchain_community.callbacks.get_openai_callback") as mock_cb_ctx:
+            mock_cb = MagicMock()
+            mock_cb_ctx.return_value.__enter__ = MagicMock(return_value=mock_cb)
+            mock_cb_ctx.return_value.__exit__ = MagicMock(return_value=False)
+            for _ in range(threshold):
+                self._invoke(chain, max_retries=1)
+
+        self.assertEqual(cb.state, CircuitState.OPEN)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
…otection (BP-4)

- Add circuit_breaker.py (threading.Lock) and circuit_breaker_async.py (asyncio.Lock) with a three-state machine: CLOSED → OPEN → HALF_OPEN → CLOSED
- Enforce single probe in HALF_OPEN via _probe_in_flight flag; concurrent callers receive CircuitBreakerOpenError immediately
- Expose module-level singleton registry (get_circuit_breaker / reset_all_circuit_breakers) from llm_modules/__init__.py
- Read CB_FAILURE_THRESHOLD (default 5) and CB_RECOVERY_TIMEOUT (default 60) from env vars at import time; unknown services fall back to openai_api config
- Exclude openai.RateLimitError from failure counter; record APIConnectionError, APITimeoutError, and InternalServerError only
- Integrate async breaker into robust_invoke_async and sync breaker into robust_invoke; open circuit returns error dict without calling the chain
- Add tests/conftest.py autouse fixture to reset both registries around every test
- Add tests/test_circuit_breaker.py: 40 tests covering all state transitions, probe-in-flight enforcement, rate-limit exclusion, registry singleton/reset, and robust_invoke / robust_invoke_async integration (no real API calls)
- Bump version 0.3.4 → 0.3.5