### PR TITLE
feat: thread session_id through BaseGraph and add graph_name to Graph…

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,20 @@
 # Changelog
 
+## [0.3.6] - 2026-04-06
+
+### Feature: thread session_id through BaseGraph and GraphState (BP-3)
+
+- Made `folder_name` optional (default `None`) in `BaseGraph.__init__`; callers that pass only `folder_name` are unaffected (full backward-compatibility)
+- Added enforcement of the OR rule at construction time: `BaseGraph.__init__` raises `ValueError` if both `folder_name` and `session_id` are `None`, eliminating deferred surprises
+- `session_id` (previously accepted but never validated) is now stored as `self.session_id` and formally recognised as a first-class session identity for database-mode operation
+- Relaxed `intro_info_check()` from a `folder_name`-only guard to an OR condition: passes when either `folder_name` or `session_id` is set, raises `ValueError` when both are absent
+- `get_subfolder()` now returns `None` instead of raising `TypeError` when `folder_name` is `None` (database mode)
+- `write_events_to_file()` returns `None` immediately and skips all file I/O when `folder_name` is `None` (database mode)
+- Added `graph_name: str` field to `GraphState` TypedDict alongside the existing `folder_name` and `session_id` fields
+- `graph_streaming()` injects `graph_name=self.workflow_name` into a copy of the initial state before passing it to `astream`, so downstream storage and logging layers can identify the source graph without additional parameters; the caller's original state dict is not mutated
+- Added `tests/test_session_id_basegraph.py` with 17 tests covering: all valid/invalid constructor/validation combinations for `folder_name` / `session_id`, `get_subfolder()` None-return in database mode, `write_events_to_file()` no-op in database mode, `graph_name` injection into astream state, non-mutation of original state dict, and `GraphState` annotation presence
+- All 170 tests pass; `ruff format` and `ruff check --fix` clean
+
 ## [0.3.5] - 2026-04-06
 
 ### Feature: async circuit breaker to protect LLM API calls

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "black_langcube"
-version = "0.3.5"
+version = "0.3.6"
 description = "A LangGraph-based extension framework for complex workflow applications, enabling the integration of various AI models and tools into a cohesive system."
 readme = "README.md"
 license = "MIT"

--- a/src/black_langcube/__init__.py
+++ b/src/black_langcube/__init__.py
@@ -2,7 +2,7 @@
 Black LangCube - A framework for building LLM applications with LangGraph.
 """
 
-__version__ = "0.3.5"
+__version__ = "0.3.6"
 __description__ = "A framework for building LLM applications with LangGraph"
 
 # Import core components to make them available from the main package

--- a/src/black_langcube/graf/graph_base.py
+++ b/src/black_langcube/graf/graph_base.py
@@ -59,7 +59,11 @@ logger = logging.getLogger(__name__)
 
 
 class BaseGraph:
-    def __init__(self, state_cls, user_message, folder_name, language, session_id=None):
+    def __init__(
+        self, state_cls, user_message, folder_name=None, language=None, session_id=None
+    ):
+        if not folder_name and not session_id:
+            raise ValueError("Either folder_name or session_id must be provided")
         self.workflow = StateGraph(state_cls)
         self.user_message = user_message
         self.folder_name = folder_name
@@ -159,7 +163,10 @@ class BaseGraph:
     def get_subfolder(self):
         """
         Returns the subfolder path where the output files will be stored.
+        Returns None when folder_name is not set (database mode).
         """
+        if not self.folder_name:
+            return None
         return Path(self.folder_name) / self.workflow_name
 
     def intro_info_check(self):
@@ -167,9 +174,9 @@ class BaseGraph:
         if not self.user_message:
             logger.error("user_message must not be empty")
             raise ValueError("user_message must not be empty")
-        if not self.folder_name:
-            logger.error("folder_name must not be empty")
-            raise ValueError("folder_name must not be empty")
+        if not self.folder_name and not self.session_id:
+            logger.error("Either folder_name or session_id must be provided")
+            raise ValueError("Either folder_name or session_id must be provided")
 
     async def graph_streaming(
         self, initial_state: dict, recursion_limit: int = 10, extra_input=None
@@ -180,8 +187,9 @@ class BaseGraph:
         """
         try:
             events = []
+            state_with_meta = {**initial_state, "graph_name": self.workflow_name}
             async for event in self.graph.astream(
-                initial_state,
+                state_with_meta,
                 {"recursion_limit": recursion_limit, **(extra_input or {})},
             ):
                 events.append(event)
@@ -193,6 +201,8 @@ class BaseGraph:
             ) from e
 
     async def write_events_to_file(self, events, output_filename: str):
+        if not self.folder_name:
+            return None
         # Ensure folder_name is a string by calling it if it's callable.
         folder = self.folder_name() if callable(self.folder_name) else self.folder_name
         subfolder = Path(folder) / self.workflow_name
@@ -301,3 +311,4 @@ class GraphState(TypedDict, total=False):
     folder_name: str
     language: str
     session_id: str
+    graph_name: str

--- a/tests/test_session_id_basegraph.py
+++ b/tests/test_session_id_basegraph.py
@@ -1,0 +1,178 @@
+"""
+Tests for BP-3: thread session_id through BaseGraph and GraphState.
+
+Covers:
+- BaseGraph raises ValueError when both folder_name and session_id are None
+- BaseGraph instantiates with only session_id (database mode)
+- BaseGraph instantiates with only folder_name (existing file mode)
+- intro_info_check() passes for each valid combination and raises for the invalid one
+- graph_name is injected into the initial state passed to astream
+- get_subfolder() returns None when folder_name is None
+- write_events_to_file() returns None when folder_name is None
+- GraphState contains a graph_name field
+"""
+
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root / "src"))
+
+from black_langcube.graf.graph_base import BaseGraph, GraphState  # noqa: E402
+
+
+def _make_graph(folder_name=None, session_id=None, user_message="hello"):
+    """Return a minimal concrete BaseGraph subclass instance."""
+
+    class _TestGraph(BaseGraph):
+        @property
+        def workflow_name(self):
+            return "test_graph"
+
+    return _TestGraph(
+        GraphState, user_message, folder_name=folder_name, session_id=session_id
+    )
+
+
+class TestBaseGraphInit(unittest.TestCase):
+    """Constructor validation: folder_name / session_id combinations."""
+
+    def test_raises_when_neither_folder_name_nor_session_id(self):
+        with self.assertRaises(ValueError):
+            _make_graph(folder_name=None, session_id=None)
+
+    def test_instantiates_with_only_folder_name(self):
+        g = _make_graph(folder_name="results/session")
+        self.assertEqual(g.folder_name, "results/session")
+        self.assertIsNone(g.session_id)
+
+    def test_instantiates_with_only_session_id(self):
+        uid = "550e8400-e29b-41d4-a716-446655440000"
+        g = _make_graph(session_id=uid)
+        self.assertEqual(g.session_id, uid)
+        self.assertIsNone(g.folder_name)
+
+    def test_instantiates_with_both(self):
+        uid = "550e8400-e29b-41d4-a716-446655440000"
+        g = _make_graph(folder_name="results/session", session_id=uid)
+        self.assertEqual(g.folder_name, "results/session")
+        self.assertEqual(g.session_id, uid)
+
+    def test_session_id_stored(self):
+        uid = "550e8400-e29b-41d4-a716-446655440001"
+        g = _make_graph(session_id=uid)
+        self.assertEqual(g.session_id, uid)
+
+
+class TestIntroInfoCheck(unittest.TestCase):
+    """intro_info_check validation."""
+
+    def test_passes_with_folder_name_only(self):
+        g = _make_graph(folder_name="results/session")
+        g.intro_info_check()  # must not raise
+
+    def test_passes_with_session_id_only(self):
+        g = _make_graph(session_id="abc-123")
+        g.intro_info_check()  # must not raise
+
+    def test_passes_with_both(self):
+        g = _make_graph(folder_name="results/session", session_id="abc-123")
+        g.intro_info_check()  # must not raise
+
+    def test_raises_when_only_user_message_missing(self):
+        g = _make_graph(folder_name="results/session", user_message="")
+        with self.assertRaises(ValueError):
+            g.intro_info_check()
+
+    def test_raises_when_folder_and_session_both_cleared(self):
+        g = _make_graph(folder_name="results/session")
+        # Simulate state where both become absent after construction
+        g.folder_name = None
+        g.session_id = None
+        with self.assertRaises(ValueError):
+            g.intro_info_check()
+
+
+class TestGetSubfolder(unittest.TestCase):
+    """get_subfolder() returns None in database mode."""
+
+    def test_returns_path_when_folder_name_set(self):
+        g = _make_graph(folder_name="results/session")
+        result = g.get_subfolder()
+        self.assertIsNotNone(result)
+        self.assertEqual(result, Path("results/session") / "test_graph")
+
+    def test_returns_none_when_folder_name_absent(self):
+        g = _make_graph(session_id="abc-123")
+        result = g.get_subfolder()
+        self.assertIsNone(result)
+
+
+class TestWriteEventsToFile(unittest.IsolatedAsyncioTestCase):
+    """write_events_to_file() returns None and skips I/O in database mode."""
+
+    async def test_returns_none_when_no_folder_name(self):
+        g = _make_graph(session_id="abc-123")
+        result = await g.write_events_to_file([{"some": "event"}], "output.json")
+        self.assertIsNone(result)
+
+
+class TestGraphNameInjection(unittest.IsolatedAsyncioTestCase):
+    """graph_name is injected into the state passed to astream."""
+
+    async def test_graph_name_in_state_passed_to_astream(self):
+        g = _make_graph(folder_name="results/session")
+
+        captured = {}
+
+        async def mock_astream(state, config):
+            captured.update(state)
+            return
+            yield  # make it an async generator
+
+        mock_graph = MagicMock()
+        mock_graph.astream = mock_astream
+        g._graph = mock_graph
+
+        await g.graph_streaming({"question": "test question"})
+
+        self.assertIn("graph_name", captured)
+        self.assertEqual(captured["graph_name"], "test_graph")
+
+    async def test_graph_name_does_not_mutate_original_state(self):
+        g = _make_graph(folder_name="results/session")
+
+        original_state = {"question": "test"}
+
+        async def mock_astream(state, config):
+            return
+            yield
+
+        mock_graph = MagicMock()
+        mock_graph.astream = mock_astream
+        g._graph = mock_graph
+
+        await g.graph_streaming(original_state)
+
+        self.assertNotIn("graph_name", original_state)
+
+
+class TestGraphStateHasGraphName(unittest.TestCase):
+    """GraphState TypedDict includes graph_name field."""
+
+    def test_graph_name_in_graphstate_annotations(self):
+        self.assertIn("graph_name", GraphState.__annotations__)
+
+    def test_graph_state_accepts_graph_name(self):
+        state: GraphState = {
+            "folder_name": "results/session",
+            "session_id": "abc-123",
+            "graph_name": "test_graph",
+        }
+        self.assertEqual(state["graph_name"], "test_graph")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
…State (BP-3)

- Make folder_name optional; raise ValueError at init if both folder_name and session_id are None
- Relax intro_info_check() to accept either folder_name or session_id
- Guard get_subfolder() and write_events_to_file() against None folder_name
- Inject graph_name=self.workflow_name into state before astream
- Add graph_name field to GraphState TypedDict
- Add tests/test_session_id_basegraph.py (17 tests)
- Bump version 0.3.5 → 0.3.6