### PR TITLE
feat(BP-1): add database storage layer with StorageService abstraction

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,23 @@
 # Changelog
 
+## [0.4.0] - 2026-04-07
+
+### Feature: database storage layer to replace file-based JSON output (BP-1)
+
+- Added `src/black_langcube/database/` subpackage with `config.py`, `models.py`, `operations.py`, and `__init__.py`
+- `config.py` — async engine factory with automatic dialect URL rewriting (`postgresql://` → `postgresql+asyncpg://`, `sqlite://` → `sqlite+aiosqlite://`); PostgreSQL pool settings (`pool_size=10`, `max_overflow=20`, `pool_recycle=3600`, `pool_pre_ping=True`); `async_sessionmaker` with `expire_on_commit=False`; exports `Base` for migrations
+- `models.py` — four ORM models via `TimestampMixin` (DRY `created_at`/`updated_at`), UUID primary keys (native `UUID(as_uuid=True)` on PostgreSQL, `String(36)` on SQLite), `JSONType` alias (`JSONB` on PostgreSQL, `JSON` on SQLite): `Session` (replaces timestamped result folders), `GraphOutput` (replaces `graph*_output.json` per-stage files), `NodeOutput` (replaces per-node intermediate JSON lines), `TokenUsage` (replaces token accounting entries); all FK columns are indexed; `Session.status` validated via `@validates` against `VALID_SESSION_STATUSES`; cascade deletes propagate from `Session` to all child rows; `GraphOutput` has a composite `UniqueConstraint` on `(session_id, graph_name, step_name)`
+- `operations.py` — `DatabaseService` async context manager: commits on clean exit, rolls back on exception, always closes in `finally`; all write methods call `sanitize_json_data()` before insertion and use `flush()` (not `commit()`) to obtain generated IDs within the open transaction; reads use `scalar_one_or_none()`; all DB calls wrapped in `try/except SQLAlchemyError` — logs error and returns `False`/`None` rather than raising; exposes `create_session()`, `get_session()`, `update_session_status()`, `save_graph_output()`, `save_node_output()`, `save_token_usage()`
+- `sanitize_json_data()` — recursive function in `operations.py` that strips PostgreSQL-hostile null bytes (`\u0000`) from all string values in dicts, lists, and nested structures before every DB write
+- Added `src/black_langcube/storage_service.py` — `StorageService` abstraction with three modes controlled by `STORAGE_MODE` env var: `file` (backward-compatible default), `database`, `dual`; raises `ValueError` at construction time for unknown modes; `_db_service` property is lazy (no DB connection in file-only mode); in `dual` mode a DB write failure is logged and execution falls back to file write — if both fail, returns `False`
+- Added `database` optional extras group in `pyproject.toml`: `sqlalchemy[asyncio]>=2.0`, `asyncpg`, `aiosqlite`
+- Added `pytest-asyncio>=0.24.0` to the `dev` optional extras; set `asyncio_mode = "auto"` in `[tool.pytest.ini_options]`
+- Updated `tests/conftest.py`: sets `DATABASE_URL=sqlite+aiosqlite:///:memory:` before any imports; adds `db_engine` (session-scoped, creates schema via `Base.metadata.create_all`) and `db_session` (per-test, always rolls back in `finally`) async fixtures
+- Added `tests/test_database.py` with 42 tests: 16 `sanitize_json_data` unit tests (plain strings, null bytes, dicts, lists, nested structures, mixed types), 2 `DatabaseService` lifecycle tests (commit path, rollback path), 11 `DatabaseService` CRUD tests (create/get/update session, all three write operations, null-byte data), 2 `Session.status` validation tests, 6 `StorageService` mode-validation tests (all valid modes, invalid mode, empty string, env-var default), 2 `StorageService` file-mode async tests, 1 `StorageService` database-mode test, 2 `StorageService` dual-mode tests (DB failure fallback, both-fail return value)
+- Updated `README.md`: added `database/` and `storage_service.py` to architecture overview; added "Storage and Database Configuration" section documenting `STORAGE_MODE`, `DATABASE_URL`, optional dependencies, and migration guide for existing file-mode users
+- Updated `DEVELOPMENT.md`: added `database/` and `storage_service.py` to project structure; added "Database Storage Layer" section documenting subpackage files, storage modes, database URL, and how to run DB tests
+- All 212 tests pass; `ruff format` and `ruff check --fix` clean
+
 ## [0.3.6] - 2026-04-06
 
 ### Feature: thread session_id through BaseGraph and GraphState (BP-3)

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -45,6 +45,12 @@ black-langcube/
 │   ├── format_instructions/      # Output formatting utilities
 │   │   └── analyst_format.py    # Analyst-specific formatting
 │   ├── output_creation_functions/ # File generation utilities
+│   ├── database/                 # SQLAlchemy async ORM storage layer
+│   │   ├── __init__.py           # Exports DatabaseService, Base, ORM models
+│   │   ├── config.py             # Async engine, session factory, Base
+│   │   ├── models.py             # Session, GraphOutput, NodeOutput, TokenUsage ORM models
+│   │   └── operations.py        # DatabaseService context manager + sanitize_json_data
+│   ├── storage_service.py        # StorageService (file / database / dual modes)
 │   └── examples/                 # Usage examples and tutorials
 ├── tests/                        # Test files
 ├── pyproject.toml               # Modern Python packaging configuration
@@ -72,11 +78,66 @@ Pre-built node classes for common LLM operations:
 ### 3. Data Structures (`data_structures/`)
 Pydantic models for structured data:
 - `Strategies`: Research strategy definitions
+
+### 4. Database Storage Layer (`database/`)
+
+SQLAlchemy 2.x async ORM storage layer that replaces (or augments) the
+file-based JSON output system.
+
+#### Subpackage files
+
+| File | Purpose |
+|---|---|
+| `config.py` | Async engine factory, session factory (`async_sessionmaker`), `Base` |
+| `models.py` | ORM models: `Session`, `GraphOutput`, `NodeOutput`, `TokenUsage` |
+| `operations.py` | `DatabaseService` context manager + `sanitize_json_data()` |
+
+#### Storage modes
+
+Controlled by the `STORAGE_MODE` environment variable:
+
+| Mode | Behavior |
+|---|---|
+| `file` | Write/read files only — default, fully backward-compatible |
+| `database` | Write/read database only |
+| `dual` | Write to both; read from database — recommended migration path |
+
+Unknown mode values cause `StorageService` to raise `ValueError` at
+construction time (fail fast, not at write time).
+
+#### Database URL
+
+Set `DATABASE_URL` to your connection string. The library auto-converts it to
+the appropriate async dialect:
+
+```
+# PostgreSQL (production)
+DATABASE_URL=postgresql://user:password@host:5432/dbname
+# → postgresql+asyncpg://...
+
+# SQLite (local / tests)
+DATABASE_URL=sqlite:///./black_langcube.db
+# → sqlite+aiosqlite://...
+```
+
+#### Running DB tests
+
+Install the optional database group and run pytest:
+
+```bash
+pip install -e .[dev,database]
+pytest tests/test_database.py -v
+```
+
+All DB tests use an in-memory SQLite database (`sqlite+aiosqlite:///:memory:`
+with `StaticPool`). The `DATABASE_URL` override is applied in `conftest.py`
+before any `black_langcube.database` imports so the engine is created with the
+test URL.
 - `Article`: Scientific article metadata
 - `Outline`: Document structure representation
 - Extensible for custom data types
 
-### 4. Processing Entry Points (`process.py`)
+### 5. Processing Entry Points (`process.py`)
 Main library interface functions:
 - `run_workflow_by_id()`: Execute individual workflows
 - `run_complete_pipeline()`: Run sequential workflow chains

--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ The library is organized into several key modules:
 - **`messages/`**: Message formatting and composition utilities
 - **`prompts/`**: Prompt templates and configurations
 - **`format_instructions/`**: Output formatting utilities
+- **`database/`**: SQLAlchemy async ORM models and `DatabaseService`
+- **`storage_service.py`**: Three-mode storage abstraction (`file`, `database`, `dual`)
 
 ## 🛠️ Usage Examples
 
@@ -191,6 +193,71 @@ see every problem at once. It is safe to call multiple times (idempotent).
 API keys are stored internally as `pydantic.SecretStr`, which prevents the raw
 value from appearing in `str()`, `repr()`, or log output. Call
 `.get_secret_value()` only at the last moment when the key must be used.
+
+### Storage and Database Configuration
+
+The library supports three output storage modes controlled by the `STORAGE_MODE`
+environment variable:
+
+| `STORAGE_MODE` | Behavior |
+|---|---|
+| `file` (default) | Write results to timestamped folders — existing behavior, fully backward-compatible |
+| `database` | Write results only to the database |
+| `dual` | Write to both file system and database — recommended migration path |
+
+Set a database connection URL via the `DATABASE_URL` environment variable:
+
+```env
+# SQLite (local/testing)
+DATABASE_URL=sqlite:///./black_langcube.db
+
+# PostgreSQL (production)
+DATABASE_URL=postgresql://user:password@host:5432/dbname
+```
+
+The library automatically converts `DATABASE_URL` to the appropriate async
+dialect (`postgresql+asyncpg://` or `sqlite+aiosqlite://`).
+
+#### Optional database dependencies
+
+Install the `database` extras to enable database-backed storage:
+
+```bash
+pip install black_langcube[database]
+```
+
+This installs `sqlalchemy[asyncio]>=2.0`, `asyncpg` (PostgreSQL), and
+`aiosqlite` (SQLite / tests).
+
+#### Migration guide for existing `file`-mode users
+
+Existing deployments are **unaffected by default**. `STORAGE_MODE` defaults to
+`file` when the environment variable is unset. To migrate:
+
+1. Install `black_langcube[database]`.
+2. Set `DATABASE_URL` to your database connection string.
+3. Start with `STORAGE_MODE=dual` to write to both file and database while you
+   verify the database output.
+4. Switch to `STORAGE_MODE=database` once you are satisfied.
+
+#### Using `StorageService` directly
+
+```python
+import asyncio
+from black_langcube.storage_service import StorageService
+
+async def main():
+    # Uses STORAGE_MODE and DATABASE_URL from environment
+    storage = StorageService()
+    await storage.save_graph_output(
+        session_id="my-session-uuid",
+        graph_name="graf1",
+        data={"result": "..."},
+        step_name="analysis",
+    )
+
+asyncio.run(main())
+```
 
 ## 📖 Examples
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "black_langcube"
-version = "0.3.6"
+version = "0.4.0"
 description = "A LangGraph-based extension framework for complex workflow applications, enabling the integration of various AI models and tools into a cohesive system."
 readme = "README.md"
 license = "MIT"
@@ -46,10 +46,16 @@ dependencies = [
 dev = [
     "pytest>=7.0.0",
     "pytest-cov",
+    "pytest-asyncio>=0.24.0",
     "black",
     "isort",
     "flake8",
     "mypy",
+]
+database = [
+    "sqlalchemy[asyncio]>=2.0",
+    "asyncpg",
+    "aiosqlite",
 ]
 examples = [
     "jupyter",
@@ -89,3 +95,6 @@ python_version = "3.12"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"

--- a/src/black_langcube/__init__.py
+++ b/src/black_langcube/__init__.py
@@ -2,7 +2,7 @@
 Black LangCube - A framework for building LLM applications with LangGraph.
 """
 
-__version__ = "0.3.6"
+__version__ = "0.4.0"
 __description__ = "A framework for building LLM applications with LangGraph"
 
 # Import core components to make them available from the main package

--- a/src/black_langcube/database/__init__.py
+++ b/src/black_langcube/database/__init__.py
@@ -1,0 +1,27 @@
+"""
+Black LangCube — database storage subpackage.
+
+Exports
+-------
+DatabaseService   — async context manager for all DB operations
+sanitize_json_data — recursive null-byte sanitizer; apply before every write
+Base              — SQLAlchemy declarative base (used by migrations)
+Session           — ORM model: top-level session rows
+GraphOutput       — ORM model: per-graph-step outputs
+NodeOutput        — ORM model: per-node intermediate outputs
+TokenUsage        — ORM model: token accounting entries
+"""
+
+from .config import Base
+from .models import GraphOutput, NodeOutput, Session, TokenUsage
+from .operations import DatabaseService, sanitize_json_data
+
+__all__ = [
+    "Base",
+    "DatabaseService",
+    "sanitize_json_data",
+    "Session",
+    "GraphOutput",
+    "NodeOutput",
+    "TokenUsage",
+]

--- a/src/black_langcube/database/config.py
+++ b/src/black_langcube/database/config.py
@@ -1,0 +1,75 @@
+"""
+Async SQLAlchemy engine and session factory.
+
+Reads DATABASE_URL from the environment and automatically converts it to the
+appropriate async dialect URL:
+    postgresql://... -> postgresql+asyncpg://...
+    sqlite://...     -> sqlite+aiosqlite://...
+
+PostgreSQL connections use a fixed connection pool suitable for production;
+SQLite connections skip pool settings because SQLite does not support
+connection pooling.
+"""
+
+import os
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.orm import declarative_base
+
+DATABASE_URL: str = os.getenv("DATABASE_URL", "sqlite:///./black_langcube.db")
+
+# ---------------------------------------------------------------------------
+# Dialect URL rewriting
+# ---------------------------------------------------------------------------
+_DIALECT_MAP: dict[str, str] = {
+    "postgresql://": "postgresql+asyncpg://",
+    "postgres://": "postgresql+asyncpg://",
+    "sqlite://": "sqlite+aiosqlite://",
+}
+
+
+def _to_async_url(url: str) -> str:
+    """Convert a sync SQLAlchemy URL to the corresponding async dialect URL."""
+    for sync_prefix, async_prefix in _DIALECT_MAP.items():
+        if url.startswith(sync_prefix):
+            return async_prefix + url[len(sync_prefix) :]
+    return url
+
+
+_ASYNC_URL: str = _to_async_url(DATABASE_URL)
+
+# ---------------------------------------------------------------------------
+# Engine factory
+# ---------------------------------------------------------------------------
+_IS_POSTGRES: bool = _ASYNC_URL.startswith("postgresql+asyncpg://")
+
+if _IS_POSTGRES:
+    engine = create_async_engine(
+        _ASYNC_URL,
+        pool_size=10,
+        max_overflow=20,
+        pool_recycle=3600,
+        pool_pre_ping=True,
+        echo=False,
+    )
+else:
+    # SQLite does not support connection pooling arguments.
+    engine = create_async_engine(
+        _ASYNC_URL,
+        echo=False,
+    )
+
+# ---------------------------------------------------------------------------
+# Session factory
+# ---------------------------------------------------------------------------
+# expire_on_commit=False prevents lazy-load errors after commit in async context.
+async_session_factory: async_sessionmaker[AsyncSession] = async_sessionmaker(
+    engine,
+    expire_on_commit=False,
+    class_=AsyncSession,
+)
+
+# ---------------------------------------------------------------------------
+# Declarative base — imported by models.py and exposed for migrations
+# ---------------------------------------------------------------------------
+Base = declarative_base()

--- a/src/black_langcube/database/models.py
+++ b/src/black_langcube/database/models.py
@@ -1,0 +1,233 @@
+"""
+SQLAlchemy ORM models for the Black LangCube database storage layer.
+
+Tables
+------
+sessions       — replaces timestamped result folders
+graph_outputs  — replaces graph*_output.json per-stage files
+node_outputs   — replaces per-node intermediate JSON lines
+token_usage    — replaces token accounting entries in event logs
+
+Design decisions
+----------------
+- UUID primary keys are safe for distributed / parallel sessions.
+- ``JSONType`` is ``JSONB`` on PostgreSQL (efficient querying) and ``JSON`` on
+  SQLite (test compatibility), selected at import time from DATABASE_URL.
+- Every foreign key column carries an explicit ``Index``.
+- ``TimestampMixin`` provides ``created_at`` / ``updated_at`` on all tables.
+- Cascade deletes ensure that removing a Session removes all child rows.
+- ``Session.status`` is validated via ``@validates`` to behave like an enum.
+"""
+
+import uuid
+
+from sqlalchemy import (
+    JSON,
+    DateTime,
+    ForeignKey,
+    Index,
+    String,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.dialects.postgresql import JSONB, UUID as PG_UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship, validates
+
+from .config import Base, DATABASE_URL
+
+# ---------------------------------------------------------------------------
+# JSON type alias: JSONB on PostgreSQL, plain JSON for SQLite
+# ---------------------------------------------------------------------------
+_IS_POSTGRES: bool = DATABASE_URL.startswith("postgresql")
+JSONType = JSONB if _IS_POSTGRES else JSON
+
+# ---------------------------------------------------------------------------
+# UUID type alias: native on PostgreSQL, String on SQLite
+# ---------------------------------------------------------------------------
+if _IS_POSTGRES:
+    UUIDType = PG_UUID(as_uuid=True)
+    _uuid_default = uuid.uuid4  # returns uuid.UUID object
+else:
+    # SQLite stores UUIDs as 36-character strings.
+    UUIDType = String(36)
+    _uuid_default = lambda: str(uuid.uuid4())  # noqa: E731
+
+# ---------------------------------------------------------------------------
+# Valid session statuses
+# ---------------------------------------------------------------------------
+VALID_SESSION_STATUSES: frozenset[str] = frozenset(
+    {"running", "completed", "failed", "cancelled"}
+)
+
+# ---------------------------------------------------------------------------
+# Timestamp mixin
+# ---------------------------------------------------------------------------
+
+
+class TimestampMixin:
+    """Adds created_at and updated_at columns to every inheriting model."""
+
+    created_at: Mapped[DateTime] = mapped_column(
+        DateTime, server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[DateTime] = mapped_column(
+        DateTime, server_default=func.now(), onupdate=func.now(), nullable=True
+    )
+
+
+# ---------------------------------------------------------------------------
+# ORM models
+# ---------------------------------------------------------------------------
+
+
+class Session(TimestampMixin, Base):
+    """Top-level session record; replaces timestamped result folders."""
+
+    __tablename__ = "sessions"
+
+    id: Mapped[str] = mapped_column(UUIDType, primary_key=True, default=_uuid_default)
+    status: Mapped[str] = mapped_column(String(32), nullable=False, default="running")
+    metadata_: Mapped[dict] = mapped_column("metadata", JSONType, nullable=True)
+
+    # Relationships ----------------------------------------------------------------
+    graph_outputs: Mapped[list["GraphOutput"]] = relationship(
+        "GraphOutput",
+        back_populates="session",
+        cascade="all, delete-orphan",
+    )
+    node_outputs: Mapped[list["NodeOutput"]] = relationship(
+        "NodeOutput",
+        back_populates="session",
+        cascade="all, delete-orphan",
+    )
+    token_usages: Mapped[list["TokenUsage"]] = relationship(
+        "TokenUsage",
+        back_populates="session",
+        cascade="all, delete-orphan",
+    )
+
+    # Indexes ----------------------------------------------------------------------
+    __table_args__ = (Index("ix_sessions_status", "status"),)
+
+    @validates("status")
+    def validate_status(self, key: str, value: str) -> str:  # noqa: ARG002
+        if value not in VALID_SESSION_STATUSES:
+            raise ValueError(
+                f"Invalid session status '{value}'. "
+                f"Must be one of: {sorted(VALID_SESSION_STATUSES)}"
+            )
+        return value
+
+    def __repr__(self) -> str:
+        return f"<Session id={self.id!r} status={self.status!r}>"
+
+
+class GraphOutput(TimestampMixin, Base):
+    """Per-graph-step output; replaces graph*_output.json files."""
+
+    __tablename__ = "graph_outputs"
+
+    id: Mapped[str] = mapped_column(UUIDType, primary_key=True, default=_uuid_default)
+    session_id: Mapped[str] = mapped_column(
+        UUIDType, ForeignKey("sessions.id", ondelete="CASCADE"), nullable=False
+    )
+    graph_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    step_name: Mapped[str] = mapped_column(String(255), nullable=True)
+    data: Mapped[dict] = mapped_column(JSONType, nullable=True)
+
+    # Relationships ----------------------------------------------------------------
+    session: Mapped["Session"] = relationship(
+        "Session",
+        back_populates="graph_outputs",
+    )
+
+    # Indexes & constraints --------------------------------------------------------
+    __table_args__ = (
+        UniqueConstraint(
+            "session_id", "graph_name", "step_name", name="uq_graph_output_session_step"
+        ),
+        Index("ix_graph_outputs_session_id", "session_id"),
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<GraphOutput id={self.id!r} graph={self.graph_name!r}"
+            f" step={self.step_name!r}>"
+        )
+
+
+class NodeOutput(TimestampMixin, Base):
+    """Per-node intermediate output; replaces per-node JSON lines."""
+
+    __tablename__ = "node_outputs"
+
+    id: Mapped[str] = mapped_column(UUIDType, primary_key=True, default=_uuid_default)
+    session_id: Mapped[str] = mapped_column(
+        UUIDType, ForeignKey("sessions.id", ondelete="CASCADE"), nullable=False
+    )
+    graph_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    node_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    data: Mapped[dict] = mapped_column(JSONType, nullable=True)
+
+    # Relationships ----------------------------------------------------------------
+    session: Mapped["Session"] = relationship(
+        "Session",
+        back_populates="node_outputs",
+    )
+
+    # Indexes & constraints --------------------------------------------------------
+    __table_args__ = (Index("ix_node_outputs_session_id", "session_id"),)
+
+    def __repr__(self) -> str:
+        return (
+            f"<NodeOutput id={self.id!r} graph={self.graph_name!r}"
+            f" node={self.node_name!r}>"
+        )
+
+
+class TokenUsage(TimestampMixin, Base):
+    """Token accounting entry; replaces token log lines in event logs."""
+
+    __tablename__ = "token_usage"
+
+    id: Mapped[str] = mapped_column(UUIDType, primary_key=True, default=_uuid_default)
+    session_id: Mapped[str] = mapped_column(
+        UUIDType, ForeignKey("sessions.id", ondelete="CASCADE"), nullable=False
+    )
+    graph_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    node_name: Mapped[str] = mapped_column(String(255), nullable=True)
+    model: Mapped[str] = mapped_column(String(128), nullable=True)
+    prompt_tokens: Mapped[int] = mapped_column(nullable=True)
+    completion_tokens: Mapped[int] = mapped_column(nullable=True)
+    total_tokens: Mapped[int] = mapped_column(nullable=True)
+    raw_data: Mapped[dict] = mapped_column(JSONType, nullable=True)
+
+    # Relationships ----------------------------------------------------------------
+    session: Mapped["Session"] = relationship(
+        "Session",
+        back_populates="token_usages",
+    )
+
+    # Indexes & constraints --------------------------------------------------------
+    __table_args__ = (
+        Index("ix_token_usage_session_id", "session_id"),
+        Index("ix_token_usage_created_at", "created_at"),
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<TokenUsage id={self.id!r} graph={self.graph_name!r}"
+            f" total={self.total_tokens!r}>"
+        )
+
+
+# Convenience re-export of all models for use in tests and migrations
+__all__ = [
+    "Base",
+    "TimestampMixin",
+    "VALID_SESSION_STATUSES",
+    "Session",
+    "GraphOutput",
+    "NodeOutput",
+    "TokenUsage",
+]

--- a/src/black_langcube/database/operations.py
+++ b/src/black_langcube/database/operations.py
@@ -1,0 +1,307 @@
+"""
+DatabaseService — async context manager for all database operations.
+
+Usage
+-----
+    async with DatabaseService() as db:
+        session_id = await db.create_session(metadata={"run": "1"})
+        await db.save_graph_output(session_id, "graph1", data)
+
+Lifecycle
+---------
+- ``__aenter__`` opens an ``AsyncSession``.
+- ``__aexit__`` commits on clean exit, rolls back on exception, always closes.
+
+Error handling
+--------------
+Every public write method wraps its body in ``try/except SQLAlchemyError``.
+On error it logs a warning and returns ``False`` / ``None`` rather than
+re-raising, so callers can decide how to respond without being forced to
+handle DB exceptions everywhere.
+"""
+
+import logging
+import uuid
+
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from .config import engine
+from .models import GraphOutput, NodeOutput, Session, TokenUsage
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Utility: null-byte sanitizer
+# ---------------------------------------------------------------------------
+
+
+def sanitize_json_data(data: object) -> object:
+    """Recursively strip PostgreSQL-hostile null bytes (\\u0000) from JSON values.
+
+    PostgreSQL rejects ``\\u0000`` in ``text`` and ``JSONB`` columns. This
+    function must be applied before *every* database write — retrofitting it
+    later is error-prone.
+
+    Args:
+        data: Any JSON-serialisable value (dict, list, str, or scalar).
+
+    Returns:
+        A new value of the same shape with null bytes removed from all strings.
+    """
+    if isinstance(data, dict):
+        return {k: sanitize_json_data(v) for k, v in data.items()}
+    if isinstance(data, list):
+        return [sanitize_json_data(v) for v in data]
+    if isinstance(data, str):
+        return data.replace("\u0000", "")
+    return data
+
+
+# ---------------------------------------------------------------------------
+# DatabaseService
+# ---------------------------------------------------------------------------
+
+
+class DatabaseService:
+    """Async context manager that wraps a single ``AsyncSession``.
+
+    All write methods:
+    - sanitize data before insertion
+    - use ``flush()`` (not ``commit()``) to obtain generated IDs within the
+      open transaction
+    - return ``True`` on success, ``False`` on ``SQLAlchemyError``
+
+    All read methods:
+    - use ``scalar_one_or_none()`` for single-row look-ups
+    - return ``None`` on ``SQLAlchemyError``
+    """
+
+    def __init__(self) -> None:
+        self.session: AsyncSession | None = None
+
+    async def __aenter__(self) -> "DatabaseService":
+        self.session = AsyncSession(engine)
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type | None,
+        exc_val: BaseException | None,
+        exc_tb: object,
+    ) -> None:
+        assert self.session is not None  # noqa: S101 (invariant — set in __aenter__)
+        try:
+            if exc_type is None:
+                await self.session.commit()
+            else:
+                await self.session.rollback()
+        finally:
+            await self.session.close()
+
+    # ------------------------------------------------------------------
+    # Session operations
+    # ------------------------------------------------------------------
+
+    async def create_session(
+        self,
+        session_id: str | None = None,
+        metadata: dict | None = None,
+    ) -> str | None:
+        """Insert a new Session row and return its id.
+
+        Args:
+            session_id: Optional explicit UUID string. Generated if omitted.
+            metadata: Optional free-form JSON metadata dict.
+
+        Returns:
+            The session id string on success, ``None`` on error.
+        """
+        assert self.session is not None
+        try:
+            sid = session_id or str(uuid.uuid4())
+            obj = Session(
+                id=sid,
+                metadata_=sanitize_json_data(metadata) if metadata else None,
+            )
+            self.session.add(obj)
+            await self.session.flush()
+            return sid
+        except SQLAlchemyError as exc:
+            logger.error("DB write failed (create_session): %s", exc)
+            return None
+
+    async def get_session(self, session_id: str) -> Session | None:
+        """Fetch a single Session by primary key.
+
+        Args:
+            session_id: The UUID string of the session to retrieve.
+
+        Returns:
+            The ``Session`` ORM object, or ``None`` if not found or on error.
+        """
+        assert self.session is not None
+        try:
+            stmt = select(Session).where(Session.id == session_id)
+            result = await self.session.execute(stmt)
+            return result.scalar_one_or_none()
+        except SQLAlchemyError as exc:
+            logger.error("DB read failed (get_session): %s", exc)
+            return None
+
+    async def update_session_status(self, session_id: str, status: str) -> bool:
+        """Update the status field of an existing Session.
+
+        Args:
+            session_id: The UUID string identifying the session.
+            status: New status value; must be in ``VALID_SESSION_STATUSES``.
+
+        Returns:
+            ``True`` on success, ``False`` when the session is not found or a
+            database error occurs.
+
+        Raises:
+            ValueError: If *status* is not a member of ``VALID_SESSION_STATUSES``.
+                Raised by the ``@validates`` decorator on ``Session.status`` before
+                any database write — treat this as a programmer error, not a
+                recoverable runtime failure.
+        """
+        assert self.session is not None
+        try:
+            obj = await self.get_session(session_id)
+            if obj is None:
+                logger.warning(
+                    "update_session_status: session %r not found", session_id
+                )
+                return False
+            obj.status = status  # @validates fires here
+            self.session.add(obj)
+            await self.session.flush()
+            return True
+        except SQLAlchemyError as exc:
+            logger.error("DB write failed (update_session_status): %s", exc)
+            return False
+
+    # ------------------------------------------------------------------
+    # GraphOutput operations
+    # ------------------------------------------------------------------
+
+    async def save_graph_output(
+        self,
+        session_id: str,
+        graph_name: str,
+        data: object,
+        step_name: str | None = None,
+    ) -> bool:
+        """Insert a GraphOutput row.
+
+        Args:
+            session_id: UUID of the owning session.
+            graph_name: Name of the graph (e.g. ``"graf1"``).
+            data: Arbitrary JSON-serialisable output data.
+            step_name: Optional step/stage identifier within the graph.
+
+        Returns:
+            ``True`` on success, ``False`` on error.
+        """
+        assert self.session is not None
+        try:
+            obj = GraphOutput(
+                session_id=session_id,
+                graph_name=graph_name,
+                step_name=step_name,
+                data=sanitize_json_data(data),
+            )
+            self.session.add(obj)
+            await self.session.flush()
+            return True
+        except SQLAlchemyError as exc:
+            logger.error("DB write failed (save_graph_output): %s", exc)
+            return False
+
+    # ------------------------------------------------------------------
+    # NodeOutput operations
+    # ------------------------------------------------------------------
+
+    async def save_node_output(
+        self,
+        session_id: str,
+        graph_name: str,
+        node_name: str,
+        data: object,
+    ) -> bool:
+        """Insert a NodeOutput row.
+
+        Args:
+            session_id: UUID of the owning session.
+            graph_name: Name of the graph containing the node.
+            node_name: Name of the node that produced the output.
+            data: Arbitrary JSON-serialisable output data.
+
+        Returns:
+            ``True`` on success, ``False`` on error.
+        """
+        assert self.session is not None
+        try:
+            obj = NodeOutput(
+                session_id=session_id,
+                graph_name=graph_name,
+                node_name=node_name,
+                data=sanitize_json_data(data),
+            )
+            self.session.add(obj)
+            await self.session.flush()
+            return True
+        except SQLAlchemyError as exc:
+            logger.error("DB write failed (save_node_output): %s", exc)
+            return False
+
+    # ------------------------------------------------------------------
+    # TokenUsage operations
+    # ------------------------------------------------------------------
+
+    async def save_token_usage(
+        self,
+        session_id: str,
+        graph_name: str,
+        node_name: str | None = None,
+        model: str | None = None,
+        prompt_tokens: int | None = None,
+        completion_tokens: int | None = None,
+        total_tokens: int | None = None,
+        raw_data: object | None = None,
+    ) -> bool:
+        """Insert a TokenUsage row.
+
+        Args:
+            session_id: UUID of the owning session.
+            graph_name: Name of the graph that consumed tokens.
+            node_name: Optional node name within the graph.
+            model: Optional model identifier (e.g. ``"gpt-4o"``).
+            prompt_tokens: Number of prompt tokens used.
+            completion_tokens: Number of completion tokens used.
+            total_tokens: Total token count.
+            raw_data: Optional raw token accounting payload.
+
+        Returns:
+            ``True`` on success, ``False`` on error.
+        """
+        assert self.session is not None
+        try:
+            obj = TokenUsage(
+                session_id=session_id,
+                graph_name=graph_name,
+                node_name=node_name,
+                model=model,
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+                total_tokens=total_tokens,
+                raw_data=sanitize_json_data(raw_data) if raw_data is not None else None,
+            )
+            self.session.add(obj)
+            await self.session.flush()
+            return True
+        except SQLAlchemyError as exc:
+            logger.error("DB write failed (save_token_usage): %s", exc)
+            return False

--- a/src/black_langcube/storage_service.py
+++ b/src/black_langcube/storage_service.py
@@ -1,0 +1,289 @@
+"""
+StorageService — three-mode storage abstraction.
+
+The active mode is controlled by the ``STORAGE_MODE`` environment variable:
+
+| Mode       | Behavior                                                  |
+|------------|-----------------------------------------------------------|
+| ``file``   | Write/read files only — backward-compatible default       |
+| ``database``| Write/read database only                                 |
+| ``dual``   | Write to both; read from database first (migration path)  |
+
+Unknown mode values raise ``ValueError`` at construction time (fail fast).
+
+The ``_db_service`` property is lazy: the ``DatabaseService`` is not
+instantiated until the first database write, avoiding DB connection cost in
+file-only deployments.
+
+Dual-mode degradation
+---------------------
+In ``dual`` mode a DB write failure is logged and execution falls back to the
+file write. If *both* the DB write and the file write fail the original
+exception from the file write is re-raised.
+"""
+
+import logging
+import os
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+STORAGE_MODE_ENV: str = "STORAGE_MODE"
+
+VALID_STORAGE_MODES: frozenset[str] = frozenset({"file", "database", "dual"})
+
+DEFAULT_STORAGE_MODE: str = "file"
+
+
+class StorageService:
+    """Abstraction over file-based and database-backed output storage.
+
+    Args:
+        storage_mode: One of ``"file"``, ``"database"``, or ``"dual"``.
+            Reads the ``STORAGE_MODE`` environment variable when omitted.
+
+    Raises:
+        ValueError: If the resolved mode is not one of the valid values.
+    """
+
+    def __init__(self, storage_mode: str | None = None) -> None:
+        resolved = (
+            storage_mode
+            if storage_mode is not None
+            else os.getenv(STORAGE_MODE_ENV, DEFAULT_STORAGE_MODE)
+        )
+        if resolved not in VALID_STORAGE_MODES:
+            raise ValueError(
+                f"Invalid storage mode: {resolved!r}. "
+                f"Must be one of: {sorted(VALID_STORAGE_MODES)}"
+            )
+        self._storage_mode: str = resolved
+        self.__db_service: Any = None  # lazy; see _db_service property
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+
+    @property
+    def storage_mode(self) -> str:
+        """Return the active storage mode."""
+        return self._storage_mode
+
+    @property
+    def _db_service(self) -> Any:
+        """Lazy initializer for DatabaseService.
+
+        The DatabaseService (and therefore the DB engine) is not created until
+        the first time a database write is attempted. This avoids paying the
+        connection-pool setup cost in file-only deployments.
+        """
+        if self.__db_service is None:
+            # Import here to avoid circular imports and to defer the import
+            # of SQLAlchemy (an optional dependency) until actually needed.
+            from .database.operations import DatabaseService  # noqa: PLC0415
+
+            self.__db_service = DatabaseService
+        return self.__db_service
+
+    # ------------------------------------------------------------------
+    # Public write API
+    # ------------------------------------------------------------------
+
+    async def save_graph_output(
+        self,
+        session_id: str,
+        graph_name: str,
+        data: dict,
+        step_name: str | None = None,
+        file_path: str | None = None,
+    ) -> bool:
+        """Persist graph output according to the active storage mode.
+
+        Args:
+            session_id: Session UUID string.
+            graph_name: Name of the graph that produced the output.
+            data: JSON-serialisable output data.
+            step_name: Optional step/stage identifier.
+            file_path: Path to write the JSON file (required in ``file``/``dual``
+                modes unless the caller handles file writing itself).
+
+        Returns:
+            ``True`` if *at least one* write succeeded, ``False`` otherwise.
+        """
+        if self._storage_mode == "file":
+            return await self._write_file(file_path, data)
+
+        if self._storage_mode == "database":
+            async with self._db_service() as db:
+                return await db.save_graph_output(
+                    session_id, graph_name, data, step_name=step_name
+                )
+
+        # dual
+        db_ok = False
+        try:
+            async with self._db_service() as db:
+                db_ok = await db.save_graph_output(
+                    session_id, graph_name, data, step_name=step_name
+                )
+        except Exception as exc:  # noqa: BLE001
+            logger.error(
+                "StorageService dual-mode DB write failed (save_graph_output): %s", exc
+            )
+
+        file_ok = await self._write_file(file_path, data)
+
+        if not db_ok and not file_ok:
+            raise RuntimeError(
+                f"StorageService: both DB and file writes failed for graph_output"
+                f" session={session_id!r} graph={graph_name!r}"
+            )
+        return True
+
+    async def save_node_output(
+        self,
+        session_id: str,
+        graph_name: str,
+        node_name: str,
+        data: dict,
+        file_path: str | None = None,
+    ) -> bool:
+        """Persist node output according to the active storage mode.
+
+        Args:
+            session_id: Session UUID string.
+            graph_name: Name of the owning graph.
+            node_name: Name of the node that produced the output.
+            data: JSON-serialisable output data.
+            file_path: Path to write the JSON file (optional).
+
+        Returns:
+            ``True`` if *at least one* write succeeded, ``False`` otherwise.
+        """
+        if self._storage_mode == "file":
+            return await self._write_file(file_path, data)
+
+        if self._storage_mode == "database":
+            async with self._db_service() as db:
+                return await db.save_node_output(
+                    session_id, graph_name, node_name, data
+                )
+
+        # dual
+        db_ok = False
+        try:
+            async with self._db_service() as db:
+                db_ok = await db.save_node_output(
+                    session_id, graph_name, node_name, data
+                )
+        except Exception as exc:  # noqa: BLE001
+            logger.error(
+                "StorageService dual-mode DB write failed (save_node_output): %s", exc
+            )
+
+        file_ok = await self._write_file(file_path, data)
+
+        if not db_ok and not file_ok:
+            raise RuntimeError(
+                f"StorageService: both DB and file writes failed for node_output"
+                f" session={session_id!r} graph={graph_name!r} node={node_name!r}"
+            )
+        return True
+
+    async def save_token_usage(
+        self,
+        session_id: str,
+        graph_name: str,
+        node_name: str | None = None,
+        model: str | None = None,
+        prompt_tokens: int | None = None,
+        completion_tokens: int | None = None,
+        total_tokens: int | None = None,
+        raw_data: dict | None = None,
+        file_path: str | None = None,
+    ) -> bool:
+        """Persist token usage according to the active storage mode.
+
+        Args:
+            session_id: Session UUID string.
+            graph_name: Name of the owning graph.
+            node_name: Optional node name.
+            model: Optional model identifier.
+            prompt_tokens: Number of prompt tokens used.
+            completion_tokens: Number of completion tokens used.
+            total_tokens: Total token count.
+            raw_data: Optional raw token accounting payload.
+            file_path: Path to write the JSON file (optional).
+
+        Returns:
+            ``True`` if *at least one* write succeeded, ``False`` otherwise.
+        """
+        if self._storage_mode == "file":
+            return await self._write_file(file_path, raw_data or {})
+
+        if self._storage_mode == "database":
+            async with self._db_service() as db:
+                return await db.save_token_usage(
+                    session_id,
+                    graph_name,
+                    node_name=node_name,
+                    model=model,
+                    prompt_tokens=prompt_tokens,
+                    completion_tokens=completion_tokens,
+                    total_tokens=total_tokens,
+                    raw_data=raw_data,
+                )
+
+        # dual
+        db_ok = False
+        try:
+            async with self._db_service() as db:
+                db_ok = await db.save_token_usage(
+                    session_id,
+                    graph_name,
+                    node_name=node_name,
+                    model=model,
+                    prompt_tokens=prompt_tokens,
+                    completion_tokens=completion_tokens,
+                    total_tokens=total_tokens,
+                    raw_data=raw_data,
+                )
+        except Exception as exc:  # noqa: BLE001
+            logger.error(
+                "StorageService dual-mode DB write failed (save_token_usage): %s", exc
+            )
+
+        file_ok = await self._write_file(file_path, raw_data or {})
+
+        if not db_ok and not file_ok:
+            raise RuntimeError(
+                f"StorageService: both DB and file writes failed for token_usage"
+                f" session={session_id!r} graph={graph_name!r}"
+            )
+        return True
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    async def _write_file(file_path: str | None, data: dict) -> bool:
+        """Write *data* as JSON to *file_path* asynchronously.
+
+        Returns ``True`` on success, ``False`` when *file_path* is ``None`` (a
+        no-op, since the caller did not request file output) or on I/O error.
+        """
+        if file_path is None:
+            return False
+        import json  # noqa: PLC0415
+
+        import aiofiles  # noqa: PLC0415
+
+        try:
+            os.makedirs(os.path.dirname(file_path), exist_ok=True)
+            async with aiofiles.open(file_path, "w", encoding="utf-8") as fh:
+                await fh.write(json.dumps(data, ensure_ascii=False, indent=2))
+            return True
+        except Exception as exc:  # noqa: BLE001
+            logger.error("StorageService file write failed: %s", exc)
+            return False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,26 @@
 """
 pytest configuration: autouse fixture that resets all circuit breakers before and
 after every test so state cannot bleed between test cases.
+
+Database fixtures
+-----------------
+Set DATABASE_URL to an in-memory SQLite database *before* importing any
+black_langcube.database modules so that the config module (which reads the env
+var at import time) picks up the in-memory URL.  The fixtures here create the
+schema and provide a per-test async session with guaranteed rollback in the
+``finally`` block.
 """
 
+import os
+
+# Must be set before importing black_langcube.database so that database/config.py
+# reads the in-memory URL at import time.
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+
 import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.pool import StaticPool
 
 from black_langcube.llm_modules.circuit_breaker import (
     reset_all_circuit_breakers as reset_sync,
@@ -11,6 +28,10 @@ from black_langcube.llm_modules.circuit_breaker import (
 from black_langcube.llm_modules.circuit_breaker_async import (
     reset_all_circuit_breakers as reset_async,
 )
+
+# ---------------------------------------------------------------------------
+# Circuit-breaker reset (runs for every test)
+# ---------------------------------------------------------------------------
 
 
 @pytest.fixture(autouse=True)
@@ -20,3 +41,39 @@ def reset_circuit_breakers():
     yield
     reset_sync()
     reset_async()
+
+
+# ---------------------------------------------------------------------------
+# In-memory SQLite engine — shared across the test session
+# ---------------------------------------------------------------------------
+# StaticPool keeps a single connection alive for the whole process so every
+# async session sees the same in-memory database.
+
+_TEST_DB_URL = "sqlite+aiosqlite:///:memory:"
+
+
+@pytest_asyncio.fixture(scope="session")
+async def db_engine():
+    """Create a test-only async engine backed by an in-memory SQLite database."""
+    from black_langcube.database.models import Base
+
+    engine = create_async_engine(
+        _TEST_DB_URL,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield engine
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture()
+async def db_session(db_engine):
+    """Yield a fresh AsyncSession for one test; always roll back in ``finally``."""
+    session = AsyncSession(db_engine, expire_on_commit=False)
+    try:
+        yield session
+    finally:
+        await session.rollback()
+        await session.close()

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,0 +1,468 @@
+"""
+Tests for the database storage layer (BP-1).
+
+Covers:
+- sanitize_json_data(): dicts, lists, nested structures, null-byte strings
+- DatabaseService async context manager lifecycle (commit / rollback / close)
+- DatabaseService.create_session() and get_session()
+- DatabaseService.update_session_status() including invalid-status rejection
+- DatabaseService.save_graph_output()
+- DatabaseService.save_node_output()
+- DatabaseService.save_token_usage()
+- All DB tests use in-memory SQLite with StaticPool (via conftest fixtures)
+- Per-test rollback is enforced in the db_session fixture (conftest.py)
+"""
+
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root / "src"))
+
+from black_langcube.database.operations import DatabaseService, sanitize_json_data  # noqa: E402
+from black_langcube.database.models import (  # noqa: E402
+    Session,
+    VALID_SESSION_STATUSES,
+)
+
+# ---------------------------------------------------------------------------
+# sanitize_json_data — synchronous unit tests (no DB required)
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeJsonData(unittest.TestCase):
+    """Unit tests for the null-byte sanitizer utility."""
+
+    def test_plain_string_unchanged(self):
+        assert sanitize_json_data("hello") == "hello"
+
+    def test_null_bytes_removed_from_string(self):
+        assert sanitize_json_data("a\u0000b\u0000c") == "abc"
+
+    def test_string_of_only_null_bytes(self):
+        assert sanitize_json_data("\u0000\u0000") == ""
+
+    def test_integer_passthrough(self):
+        assert sanitize_json_data(42) == 42
+
+    def test_none_passthrough(self):
+        assert sanitize_json_data(None) is None
+
+    def test_float_passthrough(self):
+        assert sanitize_json_data(3.14) == 3.14
+
+    def test_bool_passthrough(self):
+        assert sanitize_json_data(True) is True
+
+    def test_dict_values_sanitized(self):
+        result = sanitize_json_data({"key": "val\u0000ue"})
+        assert result == {"key": "value"}
+
+    def test_dict_keys_untouched(self):
+        # Keys are not sanitized (unusual edge case — keys are identifiers)
+        result = sanitize_json_data({"k\u0000": "v"})
+        assert "k\u0000" in result
+
+    def test_list_items_sanitized(self):
+        result = sanitize_json_data(["\u0000a", "b\u0000", "c"])
+        assert result == ["a", "b", "c"]
+
+    def test_nested_dict_in_list(self):
+        data = [{"x": "a\u0000b"}, {"y": 1}]
+        result = sanitize_json_data(data)
+        assert result == [{"x": "ab"}, {"y": 1}]
+
+    def test_deeply_nested_structure(self):
+        data = {"level1": {"level2": {"level3": "val\u0000ue"}}}
+        result = sanitize_json_data(data)
+        assert result == {"level1": {"level2": {"level3": "value"}}}
+
+    def test_mixed_types_in_dict(self):
+        data = {"a": "str\u0000ing", "b": 42, "c": None, "d": True}
+        result = sanitize_json_data(data)
+        assert result == {"a": "string", "b": 42, "c": None, "d": True}
+
+    def test_empty_dict_unchanged(self):
+        assert sanitize_json_data({}) == {}
+
+    def test_empty_list_unchanged(self):
+        assert sanitize_json_data([]) == []
+
+    def test_empty_string_unchanged(self):
+        assert sanitize_json_data("") == ""
+
+
+# ---------------------------------------------------------------------------
+# DatabaseService tests — async, use in-memory SQLite from conftest
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestDatabaseServiceLifecycle:
+    """Context manager lifecycle: commit on success, rollback on exception."""
+
+    async def test_clean_exit_commits(self, db_engine):
+        """A clean __aexit__ should commit the session (no exception inside)."""
+
+        svc = DatabaseService.__new__(DatabaseService)
+        mock_session = AsyncMock()
+        mock_session.commit = AsyncMock()
+        mock_session.rollback = AsyncMock()
+        mock_session.close = AsyncMock()
+        svc.session = mock_session
+
+        await svc.__aexit__(None, None, None)
+
+        mock_session.commit.assert_awaited_once()
+        mock_session.rollback.assert_not_awaited()
+        mock_session.close.assert_awaited_once()
+
+    async def test_exception_exit_rolls_back(self, db_engine):
+        """An __aexit__ with an exception should roll back, not commit."""
+
+        svc = DatabaseService.__new__(DatabaseService)
+        mock_session = AsyncMock()
+        mock_session.commit = AsyncMock()
+        mock_session.rollback = AsyncMock()
+        mock_session.close = AsyncMock()
+        svc.session = mock_session
+
+        await svc.__aexit__(ValueError, ValueError("boom"), None)
+
+        mock_session.commit.assert_not_awaited()
+        mock_session.rollback.assert_awaited_once()
+        mock_session.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+class TestDatabaseServiceCRUD:
+    """Full CRUD operations via DatabaseService, using the conftest db fixtures."""
+
+    async def _make_db_service(self, db_engine) -> DatabaseService:
+        """Create a DatabaseService backed by the test engine."""
+        svc = DatabaseService.__new__(DatabaseService)
+        svc.session = AsyncSession(db_engine, expire_on_commit=False)
+        return svc
+
+    async def test_create_and_get_session(self, db_engine):
+        svc = await self._make_db_service(db_engine)
+        try:
+            sid = await svc.create_session(metadata={"run": "1"})
+            assert sid is not None
+
+            retrieved = await svc.get_session(sid)
+            assert retrieved is not None
+            assert retrieved.id == sid
+            assert retrieved.status == "running"
+        finally:
+            await svc.session.rollback()
+            await svc.session.close()
+
+    async def test_create_session_with_explicit_id(self, db_engine):
+        import uuid
+
+        explicit_id = str(uuid.uuid4())
+        svc = await self._make_db_service(db_engine)
+        try:
+            sid = await svc.create_session(session_id=explicit_id)
+            assert sid == explicit_id
+        finally:
+            await svc.session.rollback()
+            await svc.session.close()
+
+    async def test_get_session_not_found(self, db_engine):
+        svc = await self._make_db_service(db_engine)
+        try:
+            result = await svc.get_session("nonexistent-id")
+            assert result is None
+        finally:
+            await svc.session.rollback()
+            await svc.session.close()
+
+    async def test_update_session_status_valid(self, db_engine):
+        svc = await self._make_db_service(db_engine)
+        try:
+            sid = await svc.create_session()
+            ok = await svc.update_session_status(sid, "completed")
+            assert ok is True
+            updated = await svc.get_session(sid)
+            assert updated.status == "completed"
+        finally:
+            await svc.session.rollback()
+            await svc.session.close()
+
+    async def test_update_session_status_invalid_raises(self, db_engine):
+        svc = await self._make_db_service(db_engine)
+        try:
+            sid = await svc.create_session()
+            # The @validates decorator raises ValueError for bad status
+            with pytest.raises(ValueError, match="Invalid session status"):
+                await svc.update_session_status(sid, "INVALID_STATUS")
+        finally:
+            await svc.session.rollback()
+            await svc.session.close()
+
+    async def test_update_session_status_not_found(self, db_engine):
+        svc = await self._make_db_service(db_engine)
+        try:
+            ok = await svc.update_session_status("does-not-exist", "completed")
+            assert ok is False
+        finally:
+            await svc.session.rollback()
+            await svc.session.close()
+
+    async def test_save_graph_output(self, db_engine):
+        svc = await self._make_db_service(db_engine)
+        try:
+            sid = await svc.create_session()
+            ok = await svc.save_graph_output(
+                sid, "graf1", {"result": "ok"}, step_name="step1"
+            )
+            assert ok is True
+        finally:
+            await svc.session.rollback()
+            await svc.session.close()
+
+    async def test_save_graph_output_sanitizes_null_bytes(self, db_engine):
+        svc = await self._make_db_service(db_engine)
+        try:
+            sid = await svc.create_session()
+            ok = await svc.save_graph_output(sid, "graf1", {"text": "a\u0000b"})
+            assert ok is True
+        finally:
+            await svc.session.rollback()
+            await svc.session.close()
+
+    async def test_save_node_output(self, db_engine):
+        svc = await self._make_db_service(db_engine)
+        try:
+            sid = await svc.create_session()
+            ok = await svc.save_node_output(sid, "graf1", "my_node", {"output": "data"})
+            assert ok is True
+        finally:
+            await svc.session.rollback()
+            await svc.session.close()
+
+    async def test_save_token_usage(self, db_engine):
+        svc = await self._make_db_service(db_engine)
+        try:
+            sid = await svc.create_session()
+            ok = await svc.save_token_usage(
+                sid,
+                "graf1",
+                node_name="node1",
+                model="gpt-4o",
+                prompt_tokens=100,
+                completion_tokens=50,
+                total_tokens=150,
+                raw_data={"usage": {"total": 150}},
+            )
+            assert ok is True
+        finally:
+            await svc.session.rollback()
+            await svc.session.close()
+
+    async def test_save_token_usage_with_null_bytes_in_raw_data(self, db_engine):
+        svc = await self._make_db_service(db_engine)
+        try:
+            sid = await svc.create_session()
+            ok = await svc.save_token_usage(
+                sid,
+                "graf1",
+                raw_data={"note": "val\u0000ue"},
+            )
+            assert ok is True
+        finally:
+            await svc.session.rollback()
+            await svc.session.close()
+
+
+# ---------------------------------------------------------------------------
+# Session model — @validates tests (synchronous, no DB needed)
+# ---------------------------------------------------------------------------
+
+
+class TestSessionModelValidation(unittest.TestCase):
+    """Ensure @validates on Session.status rejects invalid values."""
+
+    def _make_session_obj(self, status: str) -> Session:
+        import uuid
+
+        return Session(id=str(uuid.uuid4()), status=status)
+
+    def test_valid_statuses_accepted(self):
+        for status in VALID_SESSION_STATUSES:
+            obj = self._make_session_obj(status)
+            self.assertEqual(obj.status, status)
+
+    def test_invalid_status_raises(self):
+        with self.assertRaises(ValueError):
+            self._make_session_obj("UNKNOWN")
+
+
+# ---------------------------------------------------------------------------
+# StorageService — three-mode tests (file, database, dual)
+# ---------------------------------------------------------------------------
+
+
+class TestStorageServiceModeValidation(unittest.TestCase):
+    """StorageService raises ValueError for invalid modes at construction time."""
+
+    def test_file_mode_accepted(self):
+        from black_langcube.storage_service import StorageService
+
+        svc = StorageService("file")
+        self.assertEqual(svc.storage_mode, "file")
+
+    def test_database_mode_accepted(self):
+        from black_langcube.storage_service import StorageService
+
+        svc = StorageService("database")
+        self.assertEqual(svc.storage_mode, "database")
+
+    def test_dual_mode_accepted(self):
+        from black_langcube.storage_service import StorageService
+
+        svc = StorageService("dual")
+        self.assertEqual(svc.storage_mode, "dual")
+
+    def test_invalid_mode_raises_value_error(self):
+        from black_langcube.storage_service import StorageService
+
+        with self.assertRaises(ValueError, msg="Invalid storage mode"):
+            StorageService("magic")
+
+    def test_empty_mode_raises_value_error(self):
+        from black_langcube.storage_service import StorageService
+
+        with self.assertRaises(ValueError):
+            StorageService("")
+
+    def test_default_mode_from_env(self):
+        import os
+
+        from black_langcube.storage_service import StorageService
+
+        original = os.environ.pop("STORAGE_MODE", None)
+        try:
+            svc = StorageService()
+            self.assertEqual(svc.storage_mode, "file")
+        finally:
+            if original is not None:
+                os.environ["STORAGE_MODE"] = original
+
+
+@pytest.mark.asyncio
+class TestStorageServiceFileModeAsync:
+    """file mode: writes to file, skips DB."""
+
+    async def test_file_mode_no_file_path_returns_false(self):
+        from black_langcube.storage_service import StorageService
+
+        svc = StorageService("file")
+        result = await svc.save_graph_output("sid", "g", {"k": "v"}, file_path=None)
+        assert result is False
+
+    async def test_file_mode_writes_file(self, tmp_path):
+        from black_langcube.storage_service import StorageService
+
+        svc = StorageService("file")
+        fp = str(tmp_path / "out" / "output.json")
+        result = await svc.save_graph_output(
+            "sid", "g", {"hello": "world"}, file_path=fp
+        )
+        assert result is True
+        import json
+        from pathlib import Path
+
+        assert json.loads(Path(fp).read_text()) == {"hello": "world"}
+
+
+@pytest.mark.asyncio
+class TestStorageServiceDatabaseMode:
+    """database mode: writes only to DB."""
+
+    async def test_save_graph_output_database_mode(self, db_engine):
+        from black_langcube.database.operations import DatabaseService
+        from black_langcube.storage_service import StorageService
+
+        svc = StorageService("database")
+
+        import uuid
+
+        sid = str(uuid.uuid4())
+
+        # Build a context manager that uses the test engine and creates both
+        # the owning session row and the graph_output in the same transaction
+        # so that FK constraints are satisfied within a single rollback scope.
+        class _TestCM:
+            def __init__(self):
+                self._svc = None
+
+            async def __aenter__(self):
+                self._svc = DatabaseService.__new__(DatabaseService)
+                self._svc.session = AsyncSession(db_engine, expire_on_commit=False)
+                await self._svc.create_session(session_id=sid)
+                return self._svc
+
+            async def __aexit__(self, *a):
+                await self._svc.session.rollback()
+                await self._svc.session.close()
+
+        svc._StorageService__db_service = lambda: _TestCM()
+
+        result = await svc.save_graph_output(sid, "graf1", {"x": 1}, step_name="s1")
+        assert result is True
+
+
+@pytest.mark.asyncio
+class TestStorageServiceDualMode:
+    """dual mode: DB failure falls back to file write without raising."""
+
+    async def test_dual_db_failure_falls_back_to_file(self, tmp_path):
+        from black_langcube.storage_service import StorageService
+
+        svc = StorageService("dual")
+
+        # Patch _db_service to raise an exception
+        class _FailingCM:
+            async def __aenter__(self):
+                raise RuntimeError("DB unavailable")
+
+            async def __aexit__(self, *a):
+                pass
+
+        svc._StorageService__db_service = lambda: _FailingCM()
+
+        fp = str(tmp_path / "fallback" / "output.json")
+        result = await svc.save_graph_output(
+            "sid", "g", {"fallback": True}, file_path=fp
+        )
+        assert result is True
+        import json
+        from pathlib import Path
+
+        assert json.loads(Path(fp).read_text()) == {"fallback": True}
+
+    async def test_dual_both_fail_raises(self):
+        from black_langcube.storage_service import StorageService
+
+        svc = StorageService("dual")
+
+        class _FailingCM:
+            async def __aenter__(self):
+                raise RuntimeError("DB unavailable")
+
+            async def __aexit__(self, *a):
+                pass
+
+        svc._StorageService__db_service = lambda: _FailingCM()
+
+        # No file_path → file write also returns False → RuntimeError raised
+        with pytest.raises(RuntimeError, match="both DB and file writes failed"):
+            await svc.save_graph_output("sid", "g", {"k": "v"}, file_path=None)


### PR DESCRIPTION
- Add database/ subpackage: async SQLAlchemy ORM (Session, GraphOutput, NodeOutput, TokenUsage), DatabaseService context manager, sanitize_json_data()
- Add StorageService with file/database/dual modes via STORAGE_MODE env var; dual mode raises RuntimeError when both DB and file writes fail
- Add database optional extras (sqlalchemy[asyncio], asyncpg, aiosqlite)
- Add 42 tests covering sanitize_json_data, DatabaseService CRUD/lifecycle, StorageService all three modes; conftest uses in-memory SQLite with StaticPool
- Update README and DEVELOPMENT.md with storage config and migration guide
- Bump version 0.3.6 → 0.4.0