### PR TITLE
feat: StorageService session CRUD and graph-output reads (v0.4.6)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,29 @@
 # Changelog
 
+## [0.4.6] - 2026-04-13
+
+### Feature: `StorageService` session CRUD and read operations (BP-26)
+
+- **`DatabaseService` new read/update methods** in `database/operations.py`:
+  - `update_session(session_id, data)` — shallow-merges *data* into the session's `metadata_` column.
+  - `get_graph_output(session_id, graph_name)` — returns the `data` dict from the most recent `GraphOutput` row for the given session + graph combination, or `None` if none exists.
+  - `get_output_files(session_id)` — returns a list of distinct `graph_name` values for all `GraphOutput` rows belonging to a session.
+- **`StorageService` session lifecycle methods** in `storage_service.py`:
+  - `create_session(session_id, metadata)` — creates a session record (file: `{base_dir}/{session_id}/session.json`; database: delegates to `DatabaseService`; dual: DB-first with file fallback).
+  - `get_session(session_id)` — returns a `dict | None` representing the session (dual: DB-first, falls back to file on exception).
+  - `update_session(session_id, data)` — merges `data` into the session's metadata (dual: DB-first with file fallback).
+- **`StorageService` output retrieval methods** in `storage_service.py`:
+  - `get_graph_output(session_id, graph_name)` — reads output previously saved by `save_graph_output` (file: `{base_dir}/{session_id}/{graph_name}_output.json`; dual: DB-first with file fallback).
+  - `get_output_files(session_id)` — lists output identifiers: absolute `.json` paths in `file` mode, distinct `graph_name` strings in `database` mode.
+- **`base_dir` parameter on `StorageService`** — constructor now accepts an optional `base_dir` (defaults to `STORAGE_BASE_DIR` env var, then `os.getcwd()`) used by all file-mode session and read operations.
+- **Module-level singleton accessor**:
+  - `get_storage_service()` — returns a shared `StorageService` singleton, created lazily on first call.
+  - `set_storage_service(instance)` — replaces the singleton, enabling dependency injection and test overrides without monkey-patching module globals.
+- **36 new tests** in `tests/test_storage_service_crud.py` covering all new methods across all three storage modes, dual-mode fallback paths, and the singleton accessor.
+- All existing 276 tests continue to pass without modification.
+
+---
+
 ## [0.4.5] - 2026-04-12
 
 ### Feature: overridable `save_events_to_database()` hook on `BaseGraph` (BP-25)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "black_langcube"
-version = "0.4.5"
+version = "0.4.6"
 description = "A LangGraph-based extension framework for complex workflow applications, enabling the integration of various AI models and tools into a cohesive system."
 readme = "README.md"
 license = "MIT"

--- a/src/black_langcube/__init__.py
+++ b/src/black_langcube/__init__.py
@@ -2,7 +2,7 @@
 Black LangCube - A framework for building LLM applications with LangGraph.
 """
 
-__version__ = "0.4.5"
+__version__ = "0.4.6"
 __description__ = "A framework for building LLM applications with LangGraph"
 
 # Import core components to make them available from the main package

--- a/src/black_langcube/database/operations.py
+++ b/src/black_langcube/database/operations.py
@@ -218,6 +218,36 @@ class DatabaseService:
             logger.error("DB write failed (update_session_status): %s", exc)
             return False
 
+    async def update_session(self, session_id: str, data: dict) -> bool:
+        """Merge *data* into the ``metadata_`` of an existing Session row.
+
+        The provided *data* dict is merged into the existing ``metadata_``
+        value (a shallow merge). If ``metadata_`` is currently ``None`` or not
+        a dict it is replaced by *data* directly.
+
+        Args:
+            session_id: The UUID string identifying the session.
+            data: Key/value pairs to merge into ``metadata_``.
+
+        Returns:
+            ``True`` on success, ``False`` when the session is not found or a
+            database error occurs.
+        """
+        assert self.session is not None
+        try:
+            obj = await self.get_session(session_id)
+            if obj is None:
+                logger.warning("update_session: session %r not found", session_id)
+                return False
+            existing = obj.metadata_ if isinstance(obj.metadata_, dict) else {}
+            obj.metadata_ = sanitize_json_data({**existing, **data})
+            self.session.add(obj)
+            await self.session.flush()
+            return True
+        except SQLAlchemyError as exc:
+            logger.error("DB write failed (update_session): %s", exc)
+            return False
+
     # ------------------------------------------------------------------
     # GraphOutput operations
     # ------------------------------------------------------------------
@@ -254,6 +284,72 @@ class DatabaseService:
         except SQLAlchemyError as exc:
             logger.error("DB write failed (save_graph_output): %s", exc)
             return False
+
+    async def get_graph_output(self, session_id: str, graph_name: str) -> dict | None:
+        """Return the data dict from the most recent GraphOutput row.
+
+        Args:
+            session_id: UUID of the owning session.
+            graph_name: Name of the graph whose output to retrieve.
+
+        Returns:
+            The ``data`` dict from the matching row, or ``None`` if no row
+            exists for the given session and graph name.
+
+        Raises:
+            SQLAlchemyError: Re-raised on database errors so callers can
+                distinguish a missing record (``None`` return) from a DB
+                connectivity or query failure (raised exception).
+        """
+        assert self.session is not None
+        try:
+            stmt = (
+                select(GraphOutput)
+                .where(
+                    GraphOutput.session_id == session_id,
+                    GraphOutput.graph_name == graph_name,
+                )
+                .order_by(GraphOutput.created_at.desc())
+                .limit(1)
+            )
+            result = await self.session.execute(stmt)
+            row = result.scalar_one_or_none()
+            if row is None or row.data is None:
+                return None
+            return dict(row.data)
+        except SQLAlchemyError as exc:
+            logger.error("DB read failed (get_graph_output): %s", exc)
+            raise
+
+    async def get_output_files(self, session_id: str) -> list[str]:
+        """Return logical graph-name identifiers for all outputs in a session.
+
+        In database mode this returns the distinct ``graph_name`` values of
+        every :class:`GraphOutput` row belonging to *session_id*. These are
+        logical identifiers, not file-system paths — callers that need actual
+        files should use the ``file`` storage mode.
+
+        Args:
+            session_id: UUID of the owning session.
+
+        Returns:
+            A (possibly empty) list of distinct ``graph_name`` strings.
+
+        Raises:
+            SQLAlchemyError: Re-raised on database errors.
+        """
+        assert self.session is not None
+        try:
+            stmt = (
+                select(GraphOutput.graph_name)
+                .where(GraphOutput.session_id == session_id)
+                .distinct()
+            )
+            result = await self.session.execute(stmt)
+            return [row[0] for row in result.fetchall()]
+        except SQLAlchemyError as exc:
+            logger.error("DB read failed (get_output_files): %s", exc)
+            raise
 
     # ------------------------------------------------------------------
     # NodeOutput operations

--- a/src/black_langcube/storage_service.py
+++ b/src/black_langcube/storage_service.py
@@ -20,19 +20,84 @@ Dual-mode degradation
 In ``dual`` mode a DB write failure is logged and execution falls back to the
 file write. If *both* the DB write and the file write fail the original
 exception from the file write is re-raised.
+
+Dual-mode reads
+---------------
+In ``dual`` mode reads attempt the database first. On any exception the call
+falls back to the file system and logs the fallback at ``WARNING`` level.
+
+Session files (file / dual mode)
+---------------------------------
+Session metadata is stored as JSON under
+``{base_dir}/{session_id}/session.json``. The ``base_dir`` is resolved in
+priority order: constructor argument → ``STORAGE_BASE_DIR`` environment
+variable → current working directory.
+
+Singleton accessor
+------------------
+``get_storage_service()`` returns a module-level singleton. The instance can
+be replaced for testing via ``set_storage_service()``.
 """
 
+import asyncio
+import json
 import logging
 import os
 from typing import Any
 
+import aiofiles
+
 logger = logging.getLogger(__name__)
 
 STORAGE_MODE_ENV: str = "STORAGE_MODE"
+STORAGE_BASE_DIR_ENV: str = "STORAGE_BASE_DIR"
 
 VALID_STORAGE_MODES: frozenset[str] = frozenset({"file", "database", "dual"})
 
 DEFAULT_STORAGE_MODE: str = "file"
+
+SESSION_FILENAME: str = "session.json"
+GRAPH_OUTPUT_SUFFIX: str = "_output.json"
+
+# ---------------------------------------------------------------------------
+# Module-level singleton
+# ---------------------------------------------------------------------------
+
+_storage_service_instance: "StorageService | None" = None
+
+
+def get_storage_service() -> "StorageService":
+    """Return the shared ``StorageService`` singleton.
+
+    Creates the instance on the first call using the default constructor
+    (which reads ``STORAGE_MODE`` from the environment). Subsequent calls
+    return the same object.
+
+    Returns:
+        The module-level ``StorageService`` instance.
+
+    See Also:
+        :func:`set_storage_service` — replace the singleton for testing.
+    """
+    global _storage_service_instance  # noqa: PLW0603
+    if _storage_service_instance is None:
+        _storage_service_instance = StorageService()
+    return _storage_service_instance
+
+
+def set_storage_service(instance: "StorageService | None") -> None:
+    """Replace the module-level ``StorageService`` singleton.
+
+    Intended for use in tests and dependency-injection scenarios. Pass
+    ``None`` to reset the singleton so the next call to
+    :func:`get_storage_service` creates a fresh instance from the
+    environment.
+
+    Args:
+        instance: A ``StorageService`` instance (or ``None`` to clear).
+    """
+    global _storage_service_instance  # noqa: PLW0603
+    _storage_service_instance = instance
 
 
 class StorageService:
@@ -41,12 +106,21 @@ class StorageService:
     Args:
         storage_mode: One of ``"file"``, ``"database"``, or ``"dual"``.
             Reads the ``STORAGE_MODE`` environment variable when omitted.
+        base_dir: Root directory for file-mode session and output files.
+            Reads the ``STORAGE_BASE_DIR`` environment variable when omitted;
+            falls back to the current working directory. Only used by the
+            session lifecycle and output-retrieval methods in ``file`` and
+            ``dual`` modes.
 
     Raises:
         ValueError: If the resolved mode is not one of the valid values.
     """
 
-    def __init__(self, storage_mode: str | None = None) -> None:
+    def __init__(
+        self,
+        storage_mode: str | None = None,
+        base_dir: str | None = None,
+    ) -> None:
         resolved = (
             storage_mode
             if storage_mode is not None
@@ -59,6 +133,11 @@ class StorageService:
             )
         self._storage_mode: str = resolved
         self.__db_service: Any = None  # lazy; see _db_service property
+        self._base_dir: str = (
+            base_dir
+            if base_dir is not None
+            else os.getenv(STORAGE_BASE_DIR_ENV, os.getcwd())
+        )
 
     # ------------------------------------------------------------------
     # Properties
@@ -263,6 +342,276 @@ class StorageService:
         return True
 
     # ------------------------------------------------------------------
+    # Session lifecycle methods
+    # ------------------------------------------------------------------
+
+    async def create_session(
+        self,
+        session_id: str,
+        metadata: dict | None = None,
+    ) -> bool:
+        """Create a new session record according to the active storage mode.
+
+        ``file`` mode
+            Writes ``{base_dir}/{session_id}/session.json`` containing the
+            session id and the provided metadata.
+
+        ``database`` mode
+            Delegates to :meth:`DatabaseService.create_session`.
+
+        ``dual`` mode
+            Attempts the database write first; falls back to the file write
+            on any exception.
+
+        Args:
+            session_id: Unique identifier for the new session.
+            metadata: Optional free-form metadata dict to store with the
+                session.
+
+        Returns:
+            ``True`` if at least one write succeeded, ``False`` otherwise.
+        """
+        if self._storage_mode == "file":
+            return await self._write_session_file(
+                session_id, {"id": session_id, "metadata": metadata or {}}
+            )
+
+        if self._storage_mode == "database":
+            async with self._db_service() as db:
+                result = await db.create_session(
+                    session_id=session_id, metadata=metadata
+                )
+                return result is not None
+
+        # dual
+        db_ok = False
+        try:
+            async with self._db_service() as db:
+                result = await db.create_session(
+                    session_id=session_id, metadata=metadata
+                )
+                db_ok = result is not None
+        except Exception as exc:  # noqa: BLE001
+            logger.error(
+                "StorageService dual-mode DB write failed (create_session): %s", exc
+            )
+
+        file_ok = await self._write_session_file(
+            session_id, {"id": session_id, "metadata": metadata or {}}
+        )
+        if not db_ok and not file_ok:
+            raise RuntimeError(
+                f"StorageService: both DB and file writes failed for create_session"
+                f" session={session_id!r}"
+            )
+        return db_ok or file_ok
+
+    async def get_session(self, session_id: str) -> dict | None:
+        """Retrieve session data according to the active storage mode.
+
+        ``file`` mode
+            Reads ``{base_dir}/{session_id}/session.json`` and returns the
+            parsed dict, or ``None`` if the file does not exist.
+
+        ``database`` mode
+            Delegates to :meth:`DatabaseService.get_session` and converts the
+            ORM object to a plain dict with keys ``id``, ``status``,
+            ``current_node_id``, and ``metadata``.
+
+        ``dual`` mode
+            Attempts the database first; falls back to the file system on
+            any exception, logging the fallback at ``WARNING`` level.
+
+        Args:
+            session_id: The unique session identifier to look up.
+
+        Returns:
+            A dict of session data, or ``None`` if the session does not exist.
+        """
+        if self._storage_mode == "file":
+            return await self._read_session_file(session_id)
+
+        if self._storage_mode == "database":
+            async with self._db_service() as db:
+                obj = await db.get_session(session_id)
+                if obj is None:
+                    return None
+                return self._session_obj_to_dict(obj)
+
+        # dual — DB first, fall back to file
+        try:
+            async with self._db_service() as db:
+                obj = await db.get_session(session_id)
+                if obj is not None:
+                    return self._session_obj_to_dict(obj)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "StorageService dual-mode DB read failed (get_session), "
+                "falling back to file: %s",
+                exc,
+            )
+
+        return await self._read_session_file(session_id)
+
+    async def update_session(self, session_id: str, data: dict) -> bool:
+        """Merge *data* into the session's metadata according to the active mode.
+
+        ``file`` mode
+            Reads ``{base_dir}/{session_id}/session.json``, merges *data*
+            into the ``metadata`` sub-dict, and writes the file back.
+            Returns ``False`` when the session file does not yet exist.
+
+        ``database`` mode
+            Delegates to :meth:`DatabaseService.update_session`.
+
+        ``dual`` mode
+            Attempts the database write first; falls back to the file write
+            on any exception.
+
+        Args:
+            session_id: The unique session identifier to update.
+            data: Key/value pairs to merge into the session's metadata.
+
+        Returns:
+            ``True`` if at least one write succeeded, ``False`` otherwise.
+        """
+        if self._storage_mode == "file":
+            existing = await self._read_session_file(session_id)
+            if existing is None:
+                return False
+            merged_meta = {**existing.get("metadata", {}), **data}
+            return await self._write_session_file(
+                session_id, {**existing, "metadata": merged_meta}
+            )
+
+        if self._storage_mode == "database":
+            async with self._db_service() as db:
+                return await db.update_session(session_id, data)
+
+        # dual
+        db_ok = False
+        try:
+            async with self._db_service() as db:
+                db_ok = await db.update_session(session_id, data)
+        except Exception as exc:  # noqa: BLE001
+            logger.error(
+                "StorageService dual-mode DB write failed (update_session): %s", exc
+            )
+
+        existing = await self._read_session_file(session_id)
+        if existing is None:
+            if not db_ok:
+                raise RuntimeError(
+                    f"StorageService: both DB and file writes failed for update_session"
+                    f" session={session_id!r}"
+                )
+            return db_ok
+        merged_meta = {**existing.get("metadata", {}), **data}
+        file_ok = await self._write_session_file(
+            session_id, {**existing, "metadata": merged_meta}
+        )
+        if not db_ok and not file_ok:
+            raise RuntimeError(
+                f"StorageService: both DB and file writes failed for update_session"
+                f" session={session_id!r}"
+            )
+        return db_ok or file_ok
+
+    # ------------------------------------------------------------------
+    # Output retrieval methods
+    # ------------------------------------------------------------------
+
+    async def get_graph_output(self, session_id: str, graph_name: str) -> dict | None:
+        """Retrieve previously saved graph output according to the active mode.
+
+        ``file`` mode
+            Reads ``{base_dir}/{session_id}/{graph_name}_output.json`` and
+            returns the parsed dict, or ``None`` if the file does not exist.
+
+        ``database`` mode
+            Delegates to :meth:`DatabaseService.get_graph_output`.
+
+        ``dual`` mode
+            Attempts the database first; falls back to the file system on
+            any exception, logging the fallback at ``WARNING`` level.
+
+        Args:
+            session_id: The unique session identifier.
+            graph_name: Name of the graph whose output to retrieve.
+
+        Returns:
+            The output data dict, or ``None`` if no output was found.
+        """
+        if self._storage_mode == "file":
+            return await self._read_graph_output_file(session_id, graph_name)
+
+        if self._storage_mode == "database":
+            async with self._db_service() as db:
+                return await db.get_graph_output(session_id, graph_name)
+
+        # dual — DB first, fall back to file
+        try:
+            async with self._db_service() as db:
+                result = await db.get_graph_output(session_id, graph_name)
+                if result is not None:
+                    return result
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "StorageService dual-mode DB read failed (get_graph_output), "
+                "falling back to file: %s",
+                exc,
+            )
+
+        return await self._read_graph_output_file(session_id, graph_name)
+
+    async def get_output_files(self, session_id: str) -> list[str]:
+        """List output file paths or identifiers for a session.
+
+        ``file`` mode
+            Returns the absolute paths of all ``*.json`` files found under
+            ``{base_dir}/{session_id}/``. Returns an empty list when no
+            output has been written for the session.
+
+        ``database`` mode
+            Returns a list of distinct ``graph_name`` strings for all
+            :class:`~black_langcube.database.models.GraphOutput` rows
+            belonging to *session_id*. These are logical identifiers, not
+            file-system paths.
+
+        ``dual`` mode
+            Attempts the database first; falls back to the file system on
+            any exception, logging the fallback at ``WARNING`` level.
+
+        Args:
+            session_id: The unique session identifier.
+
+        Returns:
+            A (possibly empty) list of file paths (``file`` mode) or
+            ``graph_name`` strings (``database`` mode).
+        """
+        if self._storage_mode == "file":
+            return await self._list_output_files(session_id)
+
+        if self._storage_mode == "database":
+            async with self._db_service() as db:
+                return await db.get_output_files(session_id)
+
+        # dual — DB first, fall back to file
+        try:
+            async with self._db_service() as db:
+                result = await db.get_output_files(session_id)
+                if result is not None:
+                    return result
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "StorageService dual-mode DB read failed (get_output_files), "
+                "falling back to file: %s",
+                exc,
+            )
+
+        return await self._list_output_files(session_id)
+
+    # ------------------------------------------------------------------
     # Private helpers
     # ------------------------------------------------------------------
 
@@ -275,10 +624,6 @@ class StorageService:
         """
         if file_path is None:
             return False
-        import json  # noqa: PLC0415
-
-        import aiofiles  # noqa: PLC0415
-
         try:
             os.makedirs(os.path.dirname(file_path), exist_ok=True)
             async with aiofiles.open(file_path, "w", encoding="utf-8") as fh:
@@ -287,3 +632,74 @@ class StorageService:
         except Exception as exc:  # noqa: BLE001
             logger.error("StorageService file write failed: %s", exc)
             return False
+
+    def _session_dir(self, session_id: str) -> str:
+        """Return the directory that holds all files for *session_id*."""
+        return os.path.join(self._base_dir, session_id)
+
+    def _session_file_path(self, session_id: str) -> str:
+        """Return the path to the session metadata JSON file."""
+        return os.path.join(self._session_dir(session_id), SESSION_FILENAME)
+
+    def _graph_output_file_path(self, session_id: str, graph_name: str) -> str:
+        """Return the path to the graph output JSON file."""
+        return os.path.join(
+            self._session_dir(session_id),
+            f"{graph_name}{GRAPH_OUTPUT_SUFFIX}",
+        )
+
+    async def _write_session_file(self, session_id: str, data: dict) -> bool:
+        """Write session metadata to ``{base_dir}/{session_id}/session.json``."""
+        return await self._write_file(self._session_file_path(session_id), data)
+
+    async def _read_session_file(self, session_id: str) -> dict | None:
+        """Read and return the session metadata from disk, or ``None``."""
+        path = self._session_file_path(session_id)
+        if not os.path.isfile(path):
+            return None
+        try:
+            async with aiofiles.open(path, encoding="utf-8") as fh:
+                return json.loads(await fh.read())
+        except Exception as exc:  # noqa: BLE001
+            logger.error("StorageService session file read failed: %s", exc)
+            return None
+
+    async def _read_graph_output_file(
+        self, session_id: str, graph_name: str
+    ) -> dict | None:
+        """Read graph output from ``{base_dir}/{session_id}/{graph_name}_output.json``."""
+        path = self._graph_output_file_path(session_id, graph_name)
+        if not os.path.isfile(path):
+            return None
+        try:
+            async with aiofiles.open(path, encoding="utf-8") as fh:
+                return json.loads(await fh.read())
+        except Exception as exc:  # noqa: BLE001
+            logger.error("StorageService graph output file read failed: %s", exc)
+            return None
+
+    async def _list_output_files(self, session_id: str) -> list[str]:
+        """Return absolute paths of all ``*.json`` files under the session dir."""
+        session_dir = self._session_dir(session_id)
+        if not os.path.isdir(session_dir):
+            return []
+        try:
+            names = await asyncio.to_thread(os.listdir, session_dir)
+            return sorted(
+                os.path.join(session_dir, name)
+                for name in names
+                if name.endswith(".json")
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.error("StorageService output file listing failed: %s", exc)
+            return []
+
+    @staticmethod
+    def _session_obj_to_dict(obj: Any) -> dict:
+        """Convert a SQLAlchemy Session ORM object to a plain dict."""
+        return {
+            "id": obj.id,
+            "status": obj.status,
+            "current_node_id": obj.current_node_id,
+            "metadata": obj.metadata_ if obj.metadata_ is not None else {},
+        }

--- a/tests/test_storage_service_crud.py
+++ b/tests/test_storage_service_crud.py
@@ -1,0 +1,487 @@
+"""
+Tests for StorageService session CRUD and read operations (BP-26).
+
+Covers:
+- create_session / get_session / update_session round-trip for each mode
+- get_graph_output returns data previously written by save_graph_output
+- get_output_files returns expected list of paths / identifiers
+- get_storage_service() returns the same singleton on repeated calls
+- Singleton can be replaced via set_storage_service() (dependency injection)
+- DatabaseService.update_session merges metadata
+- DatabaseService.get_graph_output and get_output_files
+"""
+
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root / "src"))
+
+from black_langcube.database.operations import DatabaseService  # noqa: E402
+from black_langcube.storage_service import (  # noqa: E402
+    StorageService,
+    get_storage_service,
+    set_storage_service,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_db_service(session: AsyncSession) -> DatabaseService:
+    """Return a DatabaseService backed by the provided test session."""
+    svc = DatabaseService.__new__(DatabaseService)
+    svc.session = session
+    return svc
+
+
+def _new_sid() -> str:
+    return str(uuid.uuid4())
+
+
+def _build_db_svc(shared_session: AsyncSession) -> StorageService:
+    """Return a StorageService (database mode) that reuses *shared_session*.
+
+    All context-manager calls share the same session so writes are immediately
+    visible to subsequent reads within the same test.
+    """
+    svc = StorageService("database")
+
+    class _SharedSessionCM:
+        def __init__(self_inner):
+            self_inner._db = DatabaseService.__new__(DatabaseService)
+            self_inner._db.session = shared_session
+
+        async def __aenter__(self_inner):
+            return self_inner._db
+
+        async def __aexit__(self_inner, *a):
+            # Lifecycle controlled by test_db_session fixture.
+            pass
+
+    svc._StorageService__db_service = lambda: _SharedSessionCM()
+    return svc
+
+
+# ---------------------------------------------------------------------------
+# DatabaseService — update_session
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+class TestDatabaseServiceUpdateSession:
+    """DatabaseService.update_session merges data into metadata_."""
+
+    async def test_update_session_creates_metadata_from_empty(self, test_db_session):
+        svc = _make_db_service(test_db_session)
+        sid = await svc.create_session()
+        ok = await svc.update_session(sid, {"key": "value"})
+        assert ok is True
+        obj = await svc.get_session(sid)
+        assert obj.metadata_["key"] == "value"
+
+    async def test_update_session_merges_with_existing_metadata(self, test_db_session):
+        svc = _make_db_service(test_db_session)
+        sid = await svc.create_session(metadata={"existing": "data"})
+        ok = await svc.update_session(sid, {"new_key": "new_val"})
+        assert ok is True
+        obj = await svc.get_session(sid)
+        assert obj.metadata_["existing"] == "data"
+        assert obj.metadata_["new_key"] == "new_val"
+
+    async def test_update_session_overwrites_key(self, test_db_session):
+        svc = _make_db_service(test_db_session)
+        sid = await svc.create_session(metadata={"k": "old"})
+        await svc.update_session(sid, {"k": "new"})
+        obj = await svc.get_session(sid)
+        assert obj.metadata_["k"] == "new"
+
+    async def test_update_session_not_found_returns_false(self, test_db_session):
+        svc = _make_db_service(test_db_session)
+        ok = await svc.update_session("nonexistent-id", {"k": "v"})
+        assert ok is False
+
+
+# ---------------------------------------------------------------------------
+# DatabaseService — get_graph_output
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+class TestDatabaseServiceGetGraphOutput:
+    """DatabaseService.get_graph_output retrieves previously saved output."""
+
+    async def test_returns_saved_data(self, test_db_session):
+        svc = _make_db_service(test_db_session)
+        sid = await svc.create_session()
+        await svc.save_graph_output(sid, "graf1", {"result": 42})
+        data = await svc.get_graph_output(sid, "graf1")
+        assert data == {"result": 42}
+
+    async def test_returns_none_when_not_found(self, test_db_session):
+        svc = _make_db_service(test_db_session)
+        sid = await svc.create_session()
+        data = await svc.get_graph_output(sid, "nonexistent_graph")
+        assert data is None
+
+    async def test_returns_none_for_unknown_session(self, test_db_session):
+        svc = _make_db_service(test_db_session)
+        data = await svc.get_graph_output("unknown-session", "graf1")
+        assert data is None
+
+
+# ---------------------------------------------------------------------------
+# DatabaseService — get_output_files
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+class TestDatabaseServiceGetOutputFiles:
+    """DatabaseService.get_output_files returns graph_name identifiers."""
+
+    async def test_returns_graph_names_after_save(self, test_db_session):
+        svc = _make_db_service(test_db_session)
+        sid = await svc.create_session()
+        await svc.save_graph_output(sid, "graf1", {"x": 1})
+        await svc.save_graph_output(sid, "graf2", {"x": 2})
+        files = await svc.get_output_files(sid)
+        assert sorted(files) == ["graf1", "graf2"]
+
+    async def test_returns_empty_list_for_session_without_output(self, test_db_session):
+        svc = _make_db_service(test_db_session)
+        sid = await svc.create_session()
+        files = await svc.get_output_files(sid)
+        assert files == []
+
+    async def test_deduplicates_graph_names(self, test_db_session):
+        """The UniqueConstraint on (session_id, graph_name, step_name) means
+        distinct step_names produce separate rows but the same graph_name.
+        get_output_files must return graph_name only once per distinct value.
+
+        Here we use two different step_names to create two rows for the same
+        graph_name, then verify only one entry is returned.
+        """
+        svc = _make_db_service(test_db_session)
+        sid = await svc.create_session()
+        # Two rows with same graph_name but different step_names
+        await svc.save_graph_output(sid, "graf1", {"step": 1}, step_name="step1")
+        await svc.save_graph_output(sid, "graf1", {"step": 2}, step_name="step2")
+        files = await svc.get_output_files(sid)
+        assert files == ["graf1"]
+
+
+# ---------------------------------------------------------------------------
+# StorageService — file mode session CRUD round-trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+class TestStorageServiceFileModeSessionCRUD:
+    """File mode: create / get / update session round-trip using tmp_path."""
+
+    async def test_create_and_get_session(self, tmp_path):
+        svc = StorageService("file", base_dir=str(tmp_path))
+        sid = _new_sid()
+        ok = await svc.create_session(sid, {"run": "1"})
+        assert ok is True
+        session = await svc.get_session(sid)
+        assert session is not None
+        assert session["id"] == sid
+        assert session["metadata"]["run"] == "1"
+
+    async def test_get_session_not_found_returns_none(self, tmp_path):
+        svc = StorageService("file", base_dir=str(tmp_path))
+        result = await svc.get_session("does-not-exist")
+        assert result is None
+
+    async def test_update_session_merges_metadata(self, tmp_path):
+        svc = StorageService("file", base_dir=str(tmp_path))
+        sid = _new_sid()
+        await svc.create_session(sid, {"initial": "data"})
+        ok = await svc.update_session(sid, {"extra": "value"})
+        assert ok is True
+        session = await svc.get_session(sid)
+        assert session["metadata"]["initial"] == "data"
+        assert session["metadata"]["extra"] == "value"
+
+    async def test_update_session_not_found_returns_false(self, tmp_path):
+        svc = StorageService("file", base_dir=str(tmp_path))
+        ok = await svc.update_session("nonexistent", {"k": "v"})
+        assert ok is False
+
+
+# ---------------------------------------------------------------------------
+# StorageService — file mode output retrieval
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+class TestStorageServiceFileModeOutputRetrieval:
+    """File mode: get_graph_output reads data written by save_graph_output."""
+
+    async def test_get_graph_output_returns_saved_data(self, tmp_path):
+        svc = StorageService("file", base_dir=str(tmp_path))
+        sid = _new_sid()
+        # Write using the convention path that get_graph_output will read
+        fp = svc._graph_output_file_path(sid, "graf1")
+        await svc.save_graph_output(sid, "graf1", {"answer": 99}, file_path=fp)
+        data = await svc.get_graph_output(sid, "graf1")
+        assert data == {"answer": 99}
+
+    async def test_get_graph_output_returns_none_when_missing(self, tmp_path):
+        svc = StorageService("file", base_dir=str(tmp_path))
+        result = await svc.get_graph_output(_new_sid(), "graf1")
+        assert result is None
+
+    async def test_get_output_files_returns_paths_after_write(self, tmp_path):
+        svc = StorageService("file", base_dir=str(tmp_path))
+        sid = _new_sid()
+        fp1 = svc._graph_output_file_path(sid, "graf1")
+        fp2 = svc._graph_output_file_path(sid, "graf2")
+        await svc.save_graph_output(sid, "graf1", {"x": 1}, file_path=fp1)
+        await svc.save_graph_output(sid, "graf2", {"x": 2}, file_path=fp2)
+        files = await svc.get_output_files(sid)
+        assert len(files) == 2
+        assert all(f.endswith(".json") for f in files)
+
+    async def test_get_output_files_returns_empty_for_unknown_session(self, tmp_path):
+        svc = StorageService("file", base_dir=str(tmp_path))
+        files = await svc.get_output_files(_new_sid())
+        assert files == []
+
+    async def test_get_output_files_includes_session_json(self, tmp_path):
+        svc = StorageService("file", base_dir=str(tmp_path))
+        sid = _new_sid()
+        await svc.create_session(sid, {"x": 1})
+        files = await svc.get_output_files(sid)
+        assert any(f.endswith("session.json") for f in files)
+
+
+# ---------------------------------------------------------------------------
+# StorageService — database mode session CRUD round-trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+class TestStorageServiceDatabaseModeSessionCRUD:
+    """database mode: session CRUD delegated to DatabaseService."""
+
+    async def test_create_and_get_session(self, test_db_session):
+        svc = _build_db_svc(test_db_session)
+        sid = _new_sid()
+        ok = await svc.create_session(sid, {"run": "db"})
+        assert ok is True
+        session = await svc.get_session(sid)
+        assert session is not None
+        assert session["id"] == sid
+        assert session["metadata"]["run"] == "db"
+
+    async def test_get_session_not_found_returns_none(self, test_db_session):
+        svc = _build_db_svc(test_db_session)
+        result = await svc.get_session("no-such-session")
+        assert result is None
+
+    async def test_update_session_round_trip(self, test_db_session):
+        svc = _build_db_svc(test_db_session)
+        sid = _new_sid()
+        await svc.create_session(sid, {"initial": True})
+        ok = await svc.update_session(sid, {"extra": "added"})
+        assert ok is True
+        session = await svc.get_session(sid)
+        assert session["metadata"]["initial"] is True
+        assert session["metadata"]["extra"] == "added"
+
+
+# ---------------------------------------------------------------------------
+# StorageService — database mode output retrieval
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+class TestStorageServiceDatabaseModeOutputRetrieval:
+    """database mode: get_graph_output and get_output_files."""
+
+    async def test_get_graph_output_returns_saved_data(self, test_db_session):
+        svc = _build_db_svc(test_db_session)
+        sid = _new_sid()
+        await svc.create_session(sid)
+        await svc.save_graph_output(sid, "graf1", {"answer": 7})
+        data = await svc.get_graph_output(sid, "graf1")
+        assert data == {"answer": 7}
+
+    async def test_get_graph_output_none_when_missing(self, test_db_session):
+        svc = _build_db_svc(test_db_session)
+        sid = _new_sid()
+        await svc.create_session(sid)
+        result = await svc.get_graph_output(sid, "nonexistent")
+        assert result is None
+
+    async def test_get_output_files_returns_graph_names(self, test_db_session):
+        svc = _build_db_svc(test_db_session)
+        sid = _new_sid()
+        await svc.create_session(sid)
+        await svc.save_graph_output(sid, "graf1", {"x": 1})
+        await svc.save_graph_output(sid, "graf2", {"x": 2})
+        files = await svc.get_output_files(sid)
+        assert sorted(files) == ["graf1", "graf2"]
+
+    async def test_get_output_files_empty_for_new_session(self, test_db_session):
+        svc = _build_db_svc(test_db_session)
+        sid = _new_sid()
+        await svc.create_session(sid)
+        files = await svc.get_output_files(sid)
+        assert files == []
+
+
+# ---------------------------------------------------------------------------
+# StorageService — dual mode session CRUD
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+class TestStorageServiceDualModeSessionCRUD:
+    """dual mode: DB failure falls back to file for create and update."""
+
+    @staticmethod
+    def _failing_cm():
+        class _FailingCM:
+            async def __aenter__(self):
+                raise RuntimeError("DB unavailable")
+
+            async def __aexit__(self, *a):
+                pass
+
+        return _FailingCM()
+
+    async def test_create_session_falls_back_to_file(self, tmp_path):
+        svc = StorageService("dual", base_dir=str(tmp_path))
+        svc._StorageService__db_service = self._failing_cm
+        sid = _new_sid()
+        ok = await svc.create_session(sid, {"fallback": True})
+        assert ok is True
+        session = await svc.get_session(sid)
+        assert session["metadata"]["fallback"] is True
+
+    async def test_get_session_falls_back_to_file(self, tmp_path):
+        svc = StorageService("dual", base_dir=str(tmp_path))
+        sid = _new_sid()
+        # Write the file directly using file mode
+        file_svc = StorageService("file", base_dir=str(tmp_path))
+        await file_svc.create_session(sid, {"source": "file"})
+
+        svc._StorageService__db_service = self._failing_cm
+        session = await svc.get_session(sid)
+        assert session is not None
+        assert session["metadata"]["source"] == "file"
+
+    async def test_update_session_falls_back_to_file(self, tmp_path):
+        file_svc = StorageService("file", base_dir=str(tmp_path))
+        sid = _new_sid()
+        await file_svc.create_session(sid, {"orig": 1})
+
+        svc = StorageService("dual", base_dir=str(tmp_path))
+        svc._StorageService__db_service = self._failing_cm
+        ok = await svc.update_session(sid, {"added": 2})
+        assert ok is True
+        session = await file_svc.get_session(sid)
+        assert session["metadata"]["orig"] == 1
+        assert session["metadata"]["added"] == 2
+
+
+# ---------------------------------------------------------------------------
+# StorageService — dual mode output retrieval fallback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+class TestStorageServiceDualModeOutputRetrieval:
+    """dual mode: DB failure falls back to file for get_graph_output / get_output_files."""
+
+    @staticmethod
+    def _failing_cm():
+        class _FailingCM:
+            async def __aenter__(self):
+                raise RuntimeError("DB unavailable")
+
+            async def __aexit__(self, *a):
+                pass
+
+        return _FailingCM()
+
+    async def test_get_graph_output_falls_back_to_file(self, tmp_path):
+        svc = StorageService("dual", base_dir=str(tmp_path))
+        sid = _new_sid()
+        fp = svc._graph_output_file_path(sid, "graf1")
+        await svc.save_graph_output(sid, "graf1", {"val": 5}, file_path=fp)
+        svc._StorageService__db_service = self._failing_cm
+        data = await svc.get_graph_output(sid, "graf1")
+        assert data == {"val": 5}
+
+    async def test_get_output_files_falls_back_to_file(self, tmp_path):
+        svc = StorageService("dual", base_dir=str(tmp_path))
+        sid = _new_sid()
+        fp = svc._graph_output_file_path(sid, "graf1")
+        await svc.save_graph_output(sid, "graf1", {"v": 1}, file_path=fp)
+        svc._StorageService__db_service = self._failing_cm
+        files = await svc.get_output_files(sid)
+        assert len(files) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Singleton accessor
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGetStorageServiceSingleton:
+    """get_storage_service() returns the same instance; set_storage_service() replaces it."""
+
+    def setup_method(self):
+        # Reset singleton before each test in this class
+        set_storage_service(None)
+
+    def teardown_method(self):
+        # Clean up after each test
+        set_storage_service(None)
+
+    def test_returns_same_instance_on_repeated_calls(self):
+        svc1 = get_storage_service()
+        svc2 = get_storage_service()
+        assert svc1 is svc2
+
+    def test_returns_storage_service_instance(self):
+        svc = get_storage_service()
+        assert isinstance(svc, StorageService)
+
+    def test_set_storage_service_replaces_singleton(self):
+        custom = StorageService("file")
+        set_storage_service(custom)
+        assert get_storage_service() is custom
+
+    def test_set_storage_service_none_resets_singleton(self):
+        original = get_storage_service()
+        set_storage_service(None)
+        new_instance = get_storage_service()
+        assert new_instance is not original
+
+    def test_dependency_injection_scenario(self):
+        """Replacing the singleton does not affect callers that cached the old instance."""
+        original = get_storage_service()
+        replacement = StorageService("file")
+        set_storage_service(replacement)
+        assert get_storage_service() is replacement
+        assert get_storage_service() is not original


### PR DESCRIPTION
- Add create_session/get_session/update_session to StorageService
- Add get_graph_output/get_output_files across all storage modes
- Add DatabaseService update_session/get_graph_output/get_output_files
- Add base_dir constructor param and get/set_storage_service singleton
- 36 new tests in test_storage_service_crud.py