### PR TITLE
feat: expose circuit breaker public API and bump version to 0.4.8

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,28 @@
 # Changelog
 
+## [0.4.8] - 2026-04-13
+
+### Feature: circuit breaker API alignment — registry exposure, per-breaker reset, and exception alias (BP-28)
+
+- **`get_all_circuit_breakers() -> dict[str, CircuitBreakerAsync]`** added to `llm_modules/circuit_breaker_async.py`:
+  - Returns a shallow copy of the internal `_circuit_breaker_registry`, enabling test introspection without accessing private state.
+- **`async reset_circuit_breaker(name: str) -> None`** added to `llm_modules/circuit_breaker_async.py`:
+  - Removes a single named breaker from the registry; no-op if the name is not found.
+  - Complements the existing all-or-nothing `reset_all_circuit_breakers()`.
+- **`CircuitBreakerError`** alias introduced in `llm_modules/circuit_breaker_async.py`:
+  - Public alias for `CircuitBreakerOpenError`; both names refer to the exact same class and are interchangeable in `except` clauses.
+- **`async get_circuit_breaker_async(name: str) -> CircuitBreakerAsync`** added to `llm_modules/circuit_breaker_async.py`:
+  - Async accessor equivalent to the existing sync `get_circuit_breaker(name)`.  Returns the same singleton instance for the same name.
+- **`__init__.py` exports updated** — `CircuitBreakerAsync`, `CircuitBreakerOpenError`, `CircuitBreakerError`, `get_circuit_breaker_async`, `get_all_circuit_breakers`, `reset_all_circuit_breakers`, and `reset_circuit_breaker` are now importable directly from `black_langcube`.
+- **16 new tests** in `tests/test_circuit_breaker.py` across four new test classes:
+  - `TestGetAllCircuitBreakers` — empty registry, populated registry contents, copy semantics.
+  - `TestResetCircuitBreaker` — removes only the named breaker, leaves others intact, no-op for unknown names, fresh instance after reset.
+  - `TestCircuitBreakerErrorAlias` — alias identity, catching by both names, cross-raising.
+  - `TestGetCircuitBreakerAsync` — same instance as sync getter, successive calls, unknown service default config.
+- 287 unit tests now pass (including the 16 new ones added above).
+
+---
+
 ## [0.4.7] - 2026-04-13
 
 ### Feature: lenient (non-raising) mode for `validate_session_continuity_async` (BP-27)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "black_langcube"
-version = "0.4.7"
+version = "0.4.8"
 description = "A LangGraph-based extension framework for complex workflow applications, enabling the integration of various AI models and tools into a cohesive system."
 readme = "README.md"
 license = "MIT"

--- a/src/black_langcube/__init__.py
+++ b/src/black_langcube/__init__.py
@@ -2,7 +2,7 @@
 Black LangCube - A framework for building LLM applications with LangGraph.
 """
 
-__version__ = "0.4.7"
+__version__ = "0.4.8"
 __description__ = "A framework for building LLM applications with LangGraph"
 
 # Import core components to make them available from the main package
@@ -12,6 +12,15 @@ from .llm_modules.LLMNodes.LLMNode import LLMNode
 from .llm_modules.llm_model import LLMProvider, ModelTier, get_llm_config_summary
 from .helper_modules.get_basegraph_classes import get_basegraph_classes
 from .process import run_workflow_by_id, run_complete_pipeline, run_parallel_pipeline
+from .llm_modules.circuit_breaker_async import (
+    CircuitBreakerAsync,
+    CircuitBreakerOpenError,
+    CircuitBreakerError,
+    get_circuit_breaker_async,
+    get_all_circuit_breakers,
+    reset_all_circuit_breakers,
+    reset_circuit_breaker,
+)
 
 # Expose main components
 __all__ = [
@@ -27,4 +36,12 @@ __all__ = [
     "run_workflow_by_id",
     "run_complete_pipeline",
     "run_parallel_pipeline",
+    # Circuit breaker
+    "CircuitBreakerAsync",
+    "CircuitBreakerOpenError",
+    "CircuitBreakerError",
+    "get_circuit_breaker_async",
+    "get_all_circuit_breakers",
+    "reset_all_circuit_breakers",
+    "reset_circuit_breaker",
 ]

--- a/src/black_langcube/llm_modules/circuit_breaker_async.py
+++ b/src/black_langcube/llm_modules/circuit_breaker_async.py
@@ -37,6 +37,12 @@ class CircuitBreakerOpenError(Exception):
     """Raised when a call is attempted while the circuit is OPEN."""
 
 
+#: Public alias — both names refer to the same exception class so that
+#: code using either ``CircuitBreakerError`` or ``CircuitBreakerOpenError``
+#: can catch it with a single ``except`` clause.
+CircuitBreakerError = CircuitBreakerOpenError
+
+
 class CircuitState(Enum):
     CLOSED = "CLOSED"
     OPEN = "OPEN"
@@ -191,6 +197,64 @@ def get_circuit_breaker(service_name: str) -> CircuitBreakerAsync:
     return _circuit_breaker_registry[service_name]
 
 
+async def get_circuit_breaker_async(service_name: str) -> CircuitBreakerAsync:
+    """Async accessor — return the singleton ``CircuitBreakerAsync`` for *service_name*.
+
+    .. note::
+        Declared ``async`` for API symmetry with the local
+        ``get_async_circuit_breaker(name)`` in Search4Science so that async
+        call sites can use a uniform ``await`` style.  The function itself
+        performs no I/O.
+
+    Equivalent to the sync :func:`get_circuit_breaker` with the same
+    creation-on-first-access semantics.  Useful in async call sites that prefer
+    a uniform ``await`` style throughout.
+
+    Args:
+        service_name: Logical name of the protected service (e.g. ``"openai_api"``).
+
+    Returns:
+        The ``CircuitBreakerAsync`` instance registered under *service_name*.
+        A new instance is created if none exists yet.
+    """
+    return get_circuit_breaker(service_name)
+
+
+def get_all_circuit_breakers() -> dict[str, CircuitBreakerAsync]:
+    """Return a shallow copy of the internal circuit-breaker registry.
+
+    Intended for test introspection and per-test isolation.  Callers receive
+    a **copy** of the registry mapping so that mutations to the returned dict
+    do not affect the live registry.
+
+    Returns:
+        A ``dict`` mapping service name → ``CircuitBreakerAsync`` instance for
+        every breaker that has been created so far.
+    """
+    return dict(_circuit_breaker_registry)
+
+
 def reset_all_circuit_breakers() -> None:
     """Clear all registered circuit breakers — for use in tests only."""
     _circuit_breaker_registry.clear()
+
+
+async def reset_circuit_breaker(name: str) -> None:
+    """Remove a single named circuit breaker from the registry.
+
+    .. note::
+        Declared ``async`` for API symmetry with the local
+        ``reset_all_async_circuit_breakers()`` in Search4Science so that async
+        test teardowns can ``await`` it without a special sync wrapper.  The
+        function itself performs no I/O.
+
+    After this call the named breaker is deregistered.  The next call to
+    :func:`get_circuit_breaker` or :func:`get_circuit_breaker_async` for the
+    same *name* will create a fresh instance.
+
+    If *name* is not currently registered the function does nothing (no-op).
+
+    Args:
+        name: The service name used when the breaker was registered.
+    """
+    _circuit_breaker_registry.pop(name, None)

--- a/tests/test_circuit_breaker.py
+++ b/tests/test_circuit_breaker.py
@@ -33,9 +33,13 @@ from black_langcube.llm_modules.circuit_breaker import (  # noqa: E402
 from black_langcube.llm_modules.circuit_breaker_async import (  # noqa: E402
     CircuitBreakerAsync,
     CircuitBreakerOpenError as AsyncCircuitBreakerOpenError,
+    CircuitBreakerError as AsyncCircuitBreakerError,
     CircuitState as AsyncCircuitState,
     get_circuit_breaker as async_get_circuit_breaker,
+    get_circuit_breaker_async,
+    get_all_circuit_breakers,
     reset_all_circuit_breakers as async_reset_all_circuit_breakers,
+    reset_circuit_breaker,
 )
 
 
@@ -608,6 +612,137 @@ class TestRobustInvokeCircuitBreaker(unittest.TestCase):
             self._invoke(chain, max_retries=1)
 
         self.assertEqual(cb.state, CircuitState.OPEN)
+
+
+# ---------------------------------------------------------------------------
+# New API tests: get_all_circuit_breakers, reset_circuit_breaker,
+# CircuitBreakerError alias, get_circuit_breaker_async
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGetAllCircuitBreakers(unittest.TestCase):
+    def setUp(self):
+        async_reset_all_circuit_breakers()
+
+    def tearDown(self):
+        async_reset_all_circuit_breakers()
+
+    def test_returns_empty_dict_when_registry_is_empty(self):
+        result = get_all_circuit_breakers()
+        self.assertEqual(result, {})
+
+    def test_returns_registered_breakers(self):
+        cb_a = async_get_circuit_breaker("openai_api")
+        cb_b = async_get_circuit_breaker("gemini_api")
+        result = get_all_circuit_breakers()
+        self.assertIn("openai_api", result)
+        self.assertIn("gemini_api", result)
+        self.assertIs(result["openai_api"], cb_a)
+        self.assertIs(result["gemini_api"], cb_b)
+
+    def test_returns_copy_not_live_dict(self):
+        async_get_circuit_breaker("openai_api")
+        snapshot = get_all_circuit_breakers()
+        async_get_circuit_breaker("gemini_api")
+        # Mutating the returned copy does not add to the registry
+        snapshot["new_service"] = AsyncMock()
+        registry_after = get_all_circuit_breakers()
+        self.assertNotIn("new_service", registry_after)
+
+
+@pytest.mark.unit
+class TestResetCircuitBreaker(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        async_reset_all_circuit_breakers()
+
+    def tearDown(self):
+        async_reset_all_circuit_breakers()
+
+    async def test_removes_named_breaker(self):
+        async_get_circuit_breaker("openai_api")
+        await reset_circuit_breaker("openai_api")
+        registry = get_all_circuit_breakers()
+        self.assertNotIn("openai_api", registry)
+
+    async def test_does_not_affect_other_breakers(self):
+        async_get_circuit_breaker("openai_api")
+        cb_b = async_get_circuit_breaker("gemini_api")
+        await reset_circuit_breaker("openai_api")
+        registry = get_all_circuit_breakers()
+        self.assertNotIn("openai_api", registry)
+        self.assertIn("gemini_api", registry)
+        self.assertIs(registry["gemini_api"], cb_b)
+
+    async def test_noop_for_unknown_name(self):
+        async_get_circuit_breaker("openai_api")
+        # Should not raise
+        await reset_circuit_breaker("nonexistent_service")
+        registry = get_all_circuit_breakers()
+        self.assertIn("openai_api", registry)
+
+    async def test_next_get_creates_fresh_instance(self):
+        cb_before = async_get_circuit_breaker("openai_api")
+        await reset_circuit_breaker("openai_api")
+        cb_after = async_get_circuit_breaker("openai_api")
+        self.assertIsNot(cb_before, cb_after)
+
+
+@pytest.mark.unit
+class TestCircuitBreakerErrorAlias(unittest.IsolatedAsyncioTestCase):
+    def test_alias_is_same_class(self):
+        self.assertIs(AsyncCircuitBreakerError, AsyncCircuitBreakerOpenError)
+
+    def test_catch_with_open_error_name(self):
+        with self.assertRaises(AsyncCircuitBreakerOpenError):
+            raise AsyncCircuitBreakerOpenError("open")
+
+    def test_catch_with_error_alias_name(self):
+        with self.assertRaises(AsyncCircuitBreakerError):
+            raise AsyncCircuitBreakerOpenError("open")
+
+    def test_catch_open_error_via_alias_raise(self):
+        with self.assertRaises(AsyncCircuitBreakerOpenError):
+            raise AsyncCircuitBreakerError("open via alias")
+
+    async def test_circuit_raises_catchable_by_both_names(self):
+        cb = _make_async_breaker(threshold=1)
+        await cb.record_failure()
+        # Catch with CircuitBreakerOpenError
+        with self.assertRaises(AsyncCircuitBreakerOpenError):
+            async with cb.call():
+                pass  # pragma: no cover
+        # Catch with CircuitBreakerError alias
+        with self.assertRaises(AsyncCircuitBreakerError):
+            async with cb.call():
+                pass  # pragma: no cover
+
+
+@pytest.mark.unit
+class TestGetCircuitBreakerAsync(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        async_reset_all_circuit_breakers()
+
+    def tearDown(self):
+        async_reset_all_circuit_breakers()
+
+    async def test_returns_same_instance_as_sync_getter(self):
+        cb_sync = async_get_circuit_breaker("openai_api")
+        cb_async = await get_circuit_breaker_async("openai_api")
+        self.assertIs(cb_sync, cb_async)
+
+    async def test_returns_circuit_breaker_async_instance(self):
+        cb = await get_circuit_breaker_async("openai_api")
+        self.assertIsInstance(cb, CircuitBreakerAsync)
+
+    async def test_successive_calls_return_same_instance(self):
+        cb1 = await get_circuit_breaker_async("openai_api")
+        cb2 = await get_circuit_breaker_async("openai_api")
+        self.assertIs(cb1, cb2)
+
+    async def test_unknown_service_gets_default_config(self):
+        cb = await get_circuit_breaker_async("some_unknown_service")
+        self.assertIsInstance(cb, CircuitBreakerAsync)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds `CircuitBreakerError` alias, `get_circuit_breaker_async`, `get_all_circuit_breakers`, and `reset_circuit_breaker` to `circuit_breaker_async.py`, exports them all from the top-level package, and covers them with tests.