### PR TITLE
feat: add py.typed marker for PEP 561 compliance (BP-39)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,26 @@
 # Changelog
 
+## [0.4.12] - 2026-04-17
+
+### Feature: `py.typed` marker and PEP 561 compliance (BP-39)
+
+- **`src/black_langcube/py.typed`** added — empty marker file that signals to
+  mypy, pyright, and pylance that `black_langcube` ships inline type
+  annotations and does not require separate stub files.
+- **`pyproject.toml` updated**:
+  - `[tool.setuptools.package-data]` entry ensures `py.typed` is bundled into
+    the wheel and sdist.
+  - `"Typing :: Typed"` classifier added.
+  - Version bumped to `0.4.12`.
+- **`README.md`** — new *Type Checking (PEP 561)* section documents mypy
+  compatibility and the absence of `ignore_missing_imports` overrides.
+- **3 new tests** in `tests/test_py_typed.py`:
+  - `py.typed` is accessible via the installed package path.
+  - `py.typed` is an empty file (PEP 561 §5).
+  - `py.typed` exists in the source tree.
+
+---
+
 ## [0.4.11] - 2026-04-13
 
 ### Performance: cache tiktoken encoder at module level in `check_tokens` (BP-31)

--- a/README.md
+++ b/README.md
@@ -365,6 +365,19 @@ See the `examples/` directory for complete working examples:
 - **Scientific Article Processing**: Complex multi-step analysis pipeline
 - **Custom Data Structures**: Extending the framework with your own models
 
+## 🔬 Type Checking (PEP 561)
+
+`black_langcube` ships a `py.typed` marker file (PEP 561) so that mypy,
+pyright, and pylance can discover the package's inline type annotations without
+requiring separate stub files.
+
+```bash
+mypy --strict your_project/
+```
+
+No `ignore_missing_imports` overrides for `black_langcube.*` are needed in
+your `mypy` configuration.
+
 ## 🧪 Development
 
 ### Setting up development environment:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "black_langcube"
-version = "0.4.11"
+version = "0.4.12"
 description = "A LangGraph-based extension framework for complex workflow applications, enabling the integration of various AI models and tools into a cohesive system."
 readme = "README.md"
 license = "MIT"
@@ -22,6 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Typing :: Typed",
 ]
 keywords = ["langgraph", "workflow", "llm", "langchain", "ai"]
 requires-python = ">=3.9"
@@ -79,6 +80,9 @@ Issues = "https://github.com/cerna-kostka/black-langcube/issues"
 where = ["src"]
 include = ["black_langcube*"]
 exclude = ["tests*", "examples*"]
+
+[tool.setuptools.package-data]
+black_langcube = ["py.typed"]
 
 [tool.setuptools.package-dir]
 "" = "src"

--- a/src/black_langcube/__init__.py
+++ b/src/black_langcube/__init__.py
@@ -2,7 +2,7 @@
 Black LangCube - A framework for building LLM applications with LangGraph.
 """
 
-__version__ = "0.4.11"
+__version__ = "0.4.12"
 __description__ = "A framework for building LLM applications with LangGraph"
 
 # Import core components to make them available from the main package

--- a/tests/test_py_typed.py
+++ b/tests/test_py_typed.py
@@ -1,0 +1,53 @@
+"""
+Regression test: assert that py.typed is shipped with the installed package
+(PEP 561 compliance).  The marker must be present in the installed
+site-packages tree so that mypy / pyright can discover inline type annotations
+without requiring separate stub files.
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).parent.parent
+src_path = project_root / "src"
+sys.path.insert(0, str(src_path))
+
+
+@pytest.mark.unit
+class TestPyTypedMarker(unittest.TestCase):
+    """Ensure py.typed exists in the installed black_langcube package tree."""
+
+    def test_py_typed_exists_via_importlib_resources(self):
+        """py.typed is accessible through importlib.resources (installed tree)."""
+        import black_langcube
+
+        package_path = Path(black_langcube.__file__).parent
+        marker = package_path / "py.typed"
+        self.assertTrue(
+            marker.exists(),
+            f"py.typed marker not found in installed package at {package_path}",
+        )
+
+    def test_py_typed_is_empty_file(self):
+        """py.typed must be an empty file per PEP 561."""
+        import black_langcube
+
+        package_path = Path(black_langcube.__file__).parent
+        marker = package_path / "py.typed"
+        self.assertTrue(marker.is_file(), "py.typed must be a regular file")
+        self.assertEqual(
+            marker.stat().st_size,
+            0,
+            "py.typed must be an empty file (PEP 561 §5)",
+        )
+
+    def test_py_typed_exists_in_source_tree(self):
+        """py.typed exists in src/black_langcube/ within the repository."""
+        source_marker = src_path / "black_langcube" / "py.typed"
+        self.assertTrue(
+            source_marker.exists(),
+            f"py.typed not found in source tree at {source_marker}",
+        )


### PR DESCRIPTION
- Add empty src/black_langcube/py.typed so mypy/pyright treat the package as typed without requiring ignore_missing_imports overrides
- Include py.typed in wheel/sdist via [tool.setuptools.package-data]
- Add Typing :: Typed classifier to pyproject.toml
- Add tests/test_py_typed.py with three regression tests
- Document PEP 561 support in README (new "Type Checking" section)
- Bump version 0.4.11 → 0.4.12